### PR TITLE
Add issue triage board queries for maintainer workflow

### DIFF
--- a/MAINTAINER_WAVE_PLAYBOOK.md
+++ b/MAINTAINER_WAVE_PLAYBOOK.md
@@ -7,6 +7,38 @@ This document defines how Soroban CrashLab is operated during Drips Wave cycles.
 - **Application Rejections**: Explicitly and quickly **reject** applicants who are not a fit or if we are waiting for a specific profile. Do not leave them pending; rejecting them immediately returns their application quota.
 - **24-Hour Review SLA Alert**: AI point appeals explicitly drop in when maintainers are unresponsive for >24 hours. Given our strict "Definition of Done", we risk automated points bypassing our review if we dawdle. Review inside 24h!
 
+## Issue triage board queries
+
+Use the following saved search queries to filter the issue board during triage.
+
+### Pending review
+
+Issues with open PRs awaiting maintainer review:
+
+```
+is:open is:issue label:wave3 linked:pr
+```
+
+### Stale
+
+Issues assigned but with no activity in the last 3 days:
+
+```
+is:open is:issue label:wave3 assignee:* updated:<YYYY-MM-DD>
+```
+
+Replace `<YYYY-MM-DD>` with a date 3 days before today. For example, if today is 2026-03-25, use `updated:<2026-03-22`.
+
+### Blocked
+
+Issues explicitly marked as blocked on dependencies or external factors:
+
+```
+is:open is:issue label:wave3 label:blocked
+```
+
+If the `blocked` label does not exist, create it with color `d93f0b` and description "Blocked on dependency or external factor".
+
 ## Pre-wave checklist
 
 1. Validate that each candidate issue has scope, acceptance criteria, and complexity.

--- a/scripts/create-wave3-issues.sh
+++ b/scripts/create-wave3-issues.sh
@@ -85,6 +85,7 @@ create_label "area:ops" "8250df" "Maintainer operations"
 create_label "area:security" "b60205" "Security policies"
 create_label "type:task" "d4c5f9" "Engineering task"
 create_label "type:feature" "a2eeef" "Feature work"
+create_label "blocked" "d93f0b" "Blocked on dependency or external factor"
 
 echo "Publishing curated issues from $ISSUE_FILE"
 


### PR DESCRIPTION
created with changes to:

MAINTAINER_WAVE_PLAYBOOK.md - Added "Issue triage board queries" section with three documented queries:

Pending review: is:open is:issue label:wave3 linked:pr
Stale: is:open is:issue label:wave3 assignee:* updated:<YYYY-MM-DD> (with date calculation instructions)
Blocked: is:open is:issue label:wave3 label:blocked
scripts/create-wave3-issues.sh - Added blocked label creation for consistency

The test failure in contracts/crashlab-core is a pre-existing unrelated issue (missing SeededPrng import).

Closes #28 
