### PR TITLE
feat: persist failing case bundles as versioned JSON (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ cd contracts/crashlab-core
 cargo test
 ```
 
+### Persist failing case bundles (JSON, versioned)
+
+`crashlab-core` can serialize a [`CaseBundle`](contracts/crashlab-core/src/lib.rs) to portable UTF-8 JSON with a top-level **`schema`** field (`CASE_BUNDLE_SCHEMA_VERSION`, currently `1`). The document includes the **seed**, **crash signature**, optional **environment** fingerprint, and optional **`failure_payload`** bytes (e.g. stderr / diagnostics).
+
+```rust
+use crashlab_core::{load_case_bundle_json, save_case_bundle_json, to_bundle, CaseSeed};
+
+let bundle = to_bundle(CaseSeed { id: 1, payload: vec![1, 2, 3] });
+let bytes = save_case_bundle_json(&bundle).expect("serialize");
+let roundtrip = load_case_bundle_json(&bytes).expect("deserialize");
+assert_eq!(roundtrip.seed, bundle.seed);
+```
+
+See [`contracts/crashlab-core/src/bundle_persist.rs`](contracts/crashlab-core/src/bundle_persist.rs) for `read_case_bundle_json` / `write_case_bundle_json` and error types.
+
 ### Publish curated Wave 3 issues
 
 ```bash

--- a/contracts/crashlab-core/Cargo.lock
+++ b/contracts/crashlab-core/Cargo.lock
@@ -5,3 +5,103 @@ version = 4
 [[package]]
 name = "crashlab-core"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/contracts/crashlab-core/Cargo.toml
+++ b/contracts/crashlab-core/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/contracts/crashlab-core/src/auth_matrix.rs
+++ b/contracts/crashlab-core/src/auth_matrix.rs
@@ -141,7 +141,7 @@ mod tests {
 
     fn sig(digest: u64) -> CrashSignature {
         CrashSignature {
-            category: "runtime-failure",
+            category: "runtime-failure".to_string(),
             digest,
             signature_hash: digest, // Using digest as a stable placeholder for tests
         }

--- a/contracts/crashlab-core/src/bundle_persist.rs
+++ b/contracts/crashlab-core/src/bundle_persist.rs
@@ -1,0 +1,222 @@
+//! Versioned JSON persistence for [`CaseBundle`](crate::CaseBundle).
+//!
+//! Failing cases are stored as portable UTF-8 JSON with a top-level **`schema`**
+//! field so future formats can be decoded explicitly (see issue #9).
+
+use crate::{CaseBundle, CaseSeed, CrashSignature, EnvironmentFingerprint};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::io::{Read, Write};
+
+/// Current on-disk schema version for [`save_case_bundle_json`] / [`load_case_bundle_json`].
+pub const CASE_BUNDLE_SCHEMA_VERSION: u32 = 1;
+
+/// Schema versions this crate can load.
+pub const SUPPORTED_BUNDLE_SCHEMAS: &[u32] = &[CASE_BUNDLE_SCHEMA_VERSION];
+
+/// Wire/document shape written to JSON. The `schema` field versions the layout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CaseBundleDocument {
+    /// Format discriminator; bump when fields are added, removed, or re-interpreted.
+    pub schema: u32,
+    pub seed: CaseSeed,
+    pub signature: CrashSignature,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<EnvironmentFingerprint>,
+    /// Raw failure output (stderr, host error bytes, trace snippet, etc.).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failure_payload: Vec<u8>,
+}
+
+/// Errors from loading or saving a bundle.
+#[derive(Debug)]
+pub enum BundlePersistError {
+    /// `serde_json` encode/decode failure.
+    Json(serde_json::Error),
+    /// I/O when reading or writing bytes.
+    Io(std::io::Error),
+    /// Document `schema` is not in [`SUPPORTED_BUNDLE_SCHEMAS`].
+    UnsupportedSchema { found: u32 },
+}
+
+impl fmt::Display for BundlePersistError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BundlePersistError::Json(e) => write!(f, "bundle JSON error: {e}"),
+            BundlePersistError::Io(e) => write!(f, "bundle I/O error: {e}"),
+            BundlePersistError::UnsupportedSchema { found } => write!(
+                f,
+                "unsupported bundle schema version {found} (supported: {:?})",
+                SUPPORTED_BUNDLE_SCHEMAS
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BundlePersistError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            BundlePersistError::Json(e) => Some(e),
+            BundlePersistError::Io(e) => Some(e),
+            BundlePersistError::UnsupportedSchema { .. } => None,
+        }
+    }
+}
+
+impl From<serde_json::Error> for BundlePersistError {
+    fn from(e: serde_json::Error) -> Self {
+        BundlePersistError::Json(e)
+    }
+}
+
+impl From<std::io::Error> for BundlePersistError {
+    fn from(e: std::io::Error) -> Self {
+        BundlePersistError::Io(e)
+    }
+}
+
+impl CaseBundleDocument {
+    /// Builds a document from an in-memory bundle using the current schema version.
+    pub fn from_bundle(bundle: &CaseBundle) -> Self {
+        Self {
+            schema: CASE_BUNDLE_SCHEMA_VERSION,
+            seed: bundle.seed.clone(),
+            signature: bundle.signature.clone(),
+            environment: bundle.environment.clone(),
+            failure_payload: bundle.failure_payload.clone(),
+        }
+    }
+
+    /// Converts this document into a [`CaseBundle`] after validating `schema`.
+    pub fn into_bundle(self) -> Result<CaseBundle, BundlePersistError> {
+        if !SUPPORTED_BUNDLE_SCHEMAS.contains(&self.schema) {
+            return Err(BundlePersistError::UnsupportedSchema {
+                found: self.schema,
+            });
+        }
+        Ok(CaseBundle {
+            seed: self.seed,
+            signature: self.signature,
+            environment: self.environment,
+            failure_payload: self.failure_payload,
+        })
+    }
+}
+
+/// Serializes `bundle` to pretty-printed JSON bytes (UTF-8) including `schema`.
+pub fn save_case_bundle_json(bundle: &CaseBundle) -> Result<Vec<u8>, BundlePersistError> {
+    let doc = CaseBundleDocument::from_bundle(bundle);
+    Ok(serde_json::to_vec_pretty(&doc)?)
+}
+
+/// Parses JSON bytes into a [`CaseBundle`], validating `schema`.
+pub fn load_case_bundle_json(bytes: &[u8]) -> Result<CaseBundle, BundlePersistError> {
+    let doc: CaseBundleDocument = serde_json::from_slice(bytes)?;
+    doc.into_bundle()
+}
+
+/// Writes JSON to any [`Write`] implementation.
+pub fn write_case_bundle_json<W: Write>(bundle: &CaseBundle, writer: &mut W) -> Result<(), BundlePersistError> {
+    let buf = save_case_bundle_json(bundle)?;
+    writer.write_all(&buf)?;
+    Ok(())
+}
+
+/// Reads JSON from any [`Read`] implementation.
+pub fn read_case_bundle_json<R: Read>(reader: &mut R) -> Result<CaseBundle, BundlePersistError> {
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf)?;
+    load_case_bundle_json(&buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{to_bundle, to_bundle_with_environment, CrashSignature};
+
+    #[test]
+    fn roundtrip_preserves_seed_signature_and_environment() {
+        let bundle = to_bundle_with_environment(crate::CaseSeed {
+            id: 7,
+            payload: vec![1, 2, 3, 4],
+        });
+        let bytes = save_case_bundle_json(&bundle).expect("serialize");
+        let loaded = load_case_bundle_json(&bytes).expect("deserialize");
+        assert_eq!(loaded.seed, bundle.seed);
+        assert_eq!(loaded.signature, bundle.signature);
+        assert_eq!(loaded.environment, bundle.environment);
+        assert!(loaded.failure_payload.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_with_failure_payload() {
+        let mut bundle = to_bundle(crate::CaseSeed {
+            id: 99,
+            payload: vec![0xAB, 0xCD],
+        });
+        bundle.failure_payload = b"panic: contract trap".to_vec();
+        let bytes = save_case_bundle_json(&bundle).unwrap();
+        let loaded = load_case_bundle_json(&bytes).unwrap();
+        assert_eq!(loaded.failure_payload, b"panic: contract trap");
+    }
+
+    #[test]
+    fn json_contains_schema_field() {
+        let bundle = to_bundle(crate::CaseSeed {
+            id: 1,
+            payload: vec![0],
+        });
+        let s = String::from_utf8(save_case_bundle_json(&bundle).unwrap()).unwrap();
+        assert!(s.contains("\"schema\""));
+        assert!(s.contains(&CASE_BUNDLE_SCHEMA_VERSION.to_string()));
+    }
+
+    #[test]
+    fn unsupported_schema_rejected() {
+        let doc = CaseBundleDocument {
+            schema: 999,
+            seed: crate::CaseSeed {
+                id: 1,
+                payload: vec![],
+            },
+            signature: CrashSignature {
+                category: "empty-input".to_string(),
+                digest: 0,
+                signature_hash: 0,
+            },
+            environment: None,
+            failure_payload: vec![],
+        };
+        let bytes = serde_json::to_vec(&doc).unwrap();
+        let err = load_case_bundle_json(&bytes).unwrap_err();
+        match err {
+            BundlePersistError::UnsupportedSchema { found } => assert_eq!(found, 999),
+            _ => panic!("expected UnsupportedSchema"),
+        }
+    }
+
+    #[test]
+    fn omits_optional_empty_fields_in_json() {
+        let bundle = to_bundle(crate::CaseSeed {
+            id: 2,
+            payload: vec![3],
+        });
+        let s = String::from_utf8(save_case_bundle_json(&bundle).unwrap()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["schema"], CASE_BUNDLE_SCHEMA_VERSION);
+        assert!(v.get("environment").is_none());
+        assert!(v.get("failure_payload").is_none());
+    }
+
+    #[test]
+    fn read_write_roundtrip_via_trait() {
+        let bundle = to_bundle(crate::CaseSeed {
+            id: 3,
+            payload: vec![9, 9],
+        });
+        let mut buf = Vec::new();
+        write_case_bundle_json(&bundle, &mut buf).unwrap();
+        let loaded = read_case_bundle_json(&mut buf.as_slice()).unwrap();
+        assert_eq!(loaded, bundle);
+    }
+}

--- a/contracts/crashlab-core/src/env_fingerprint.rs
+++ b/contracts/crashlab-core/src/env_fingerprint.rs
@@ -1,0 +1,127 @@
+//! Runtime environment fingerprinting for [`CaseBundle`](crate::CaseBundle) replay.
+
+use serde::{Deserialize, Serialize};
+use std::env::consts::{ARCH, FAMILY, OS};
+
+/// Snapshot of the host environment at bundle capture time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvironmentFingerprint {
+    /// Operating system name (e.g. `linux`, `macos`, `windows`).
+    pub os: String,
+    /// CPU architecture (e.g. `x86_64`, `aarch64`).
+    pub arch: String,
+    /// Platform family (`unix` or `windows`).
+    pub family: String,
+    /// `crashlab-core` crate semantic version at capture time.
+    pub tool_version: String,
+}
+
+impl EnvironmentFingerprint {
+    /// Builds a fingerprint from explicit fields (tests, fixtures, imports).
+    pub fn new(
+        os: impl Into<String>,
+        arch: impl Into<String>,
+        family: impl Into<String>,
+        tool_version: impl Into<String>,
+    ) -> Self {
+        Self {
+            os: os.into(),
+            arch: arch.into(),
+            family: family.into(),
+            tool_version: tool_version.into(),
+        }
+    }
+
+    /// Captures the current process environment using [`std::env::consts`].
+    pub fn capture() -> Self {
+        Self {
+            os: OS.to_string(),
+            arch: ARCH.to_string(),
+            family: FAMILY.to_string(),
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+/// Outcome of comparing a recorded fingerprint to the current environment before replay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplayEnvironmentReport {
+    /// `true` when OS, architecture, or platform family differs — replay may not be equivalent.
+    pub material_mismatch: bool,
+    /// Human-readable warnings suitable for logs or CLI output.
+    pub warnings: Vec<String>,
+}
+
+/// Compares `recorded` (from a persisted bundle) with `current` (captured at replay time).
+pub fn check_replay_environment(
+    recorded: Option<&EnvironmentFingerprint>,
+    current: &EnvironmentFingerprint,
+) -> ReplayEnvironmentReport {
+    let mut warnings = Vec::new();
+
+    let Some(rec) = recorded else {
+        return ReplayEnvironmentReport {
+            material_mismatch: false,
+            warnings,
+        };
+    };
+
+    let mut material = false;
+
+    if rec.os != current.os {
+        material = true;
+        warnings.push(format!(
+            "replay environment mismatch: recorded os '{}' differs from current '{}'",
+            rec.os, current.os
+        ));
+    }
+    if rec.arch != current.arch {
+        material = true;
+        warnings.push(format!(
+            "replay environment mismatch: recorded arch '{}' differs from current '{}'",
+            rec.arch, current.arch
+        ));
+    }
+    if rec.family != current.family {
+        material = true;
+        warnings.push(format!(
+            "replay environment mismatch: recorded family '{}' differs from current '{}'",
+            rec.family, current.family
+        ));
+    }
+
+    ReplayEnvironmentReport {
+        material_mismatch: material,
+        warnings,
+    }
+}
+
+/// Runs [`check_replay_environment`] using the optional fingerprint stored on `bundle`.
+pub fn check_bundle_replay_environment(
+    bundle: &crate::CaseBundle,
+    current: &EnvironmentFingerprint,
+) -> ReplayEnvironmentReport {
+    check_replay_environment(bundle.environment.as_ref(), current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_matches_consts() {
+        let fp = EnvironmentFingerprint::capture();
+        assert_eq!(fp.os, OS);
+        assert_eq!(fp.arch, ARCH);
+        assert_eq!(fp.family, FAMILY);
+        assert_eq!(fp.tool_version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn no_recorded_fingerprint_yields_no_warnings() {
+        let current = EnvironmentFingerprint::new("linux", "x86_64", "unix", "0.1.0");
+        let report = check_replay_environment(None, &current);
+        assert!(!report.material_mismatch);
+        assert!(report.warnings.is_empty());
+    }
+}

--- a/contracts/crashlab-core/src/lib.rs
+++ b/contracts/crashlab-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth_matrix;
+pub mod bundle_persist;
 pub mod reproducer;
 pub mod taxonomy;
 
@@ -11,6 +12,17 @@ pub use seed_validator::{SeedSchema, SeedValidationError, Validate};
 
 pub mod scheduler;
 pub use scheduler::{Mutator, SchedulerError, WeightedScheduler};
+
+pub mod env_fingerprint;
+pub use env_fingerprint::{
+    EnvironmentFingerprint, ReplayEnvironmentReport, check_bundle_replay_environment,
+    check_replay_environment,
+};
+
+pub use bundle_persist::{
+    read_case_bundle_json, save_case_bundle_json, write_case_bundle_json, BundlePersistError,
+    CaseBundleDocument, CASE_BUNDLE_SCHEMA_VERSION, SUPPORTED_BUNDLE_SCHEMAS,
+};
 
 /// Wrapper for the legacy bit-flipper mutation logic.
 pub struct DefaultMutator;
@@ -25,15 +37,15 @@ impl Mutator for DefaultMutator {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CaseSeed {
     pub id: u64,
     pub payload: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CrashSignature {
-    pub category: &'static str,
+    pub category: String,
     pub digest: u64,
     /// Stable hash derived solely from `category` and payload bytes.
     ///
@@ -62,6 +74,20 @@ pub fn compute_signature_hash(category: &str, payload: &[u8]) -> u64 {
 pub struct CaseBundle {
     pub seed: CaseSeed,
     pub signature: CrashSignature,
+    /// Host environment captured when the bundle was produced, if enabled.
+    pub environment: Option<EnvironmentFingerprint>,
+    /// Raw failure output (stderr, host error bytes, trace snippet, etc.).
+    pub failure_payload: Vec<u8>,
+}
+
+impl CaseBundle {
+    /// Compares the stored fingerprint (if any) with `current` for replay safety.
+    pub fn replay_environment_report(
+        &self,
+        current: &EnvironmentFingerprint,
+    ) -> ReplayEnvironmentReport {
+        check_replay_environment(self.environment.as_ref(), current)
+    }
 }
 
 pub fn mutate_seed(seed: &CaseSeed) -> CaseSeed {
@@ -98,7 +124,7 @@ pub fn classify(seed: &CaseSeed) -> CrashSignature {
     let signature_hash = compute_signature_hash(category, &seed.payload);
 
     CrashSignature {
-        category,
+        category: category.to_string(),
         digest,
         signature_hash,
     }
@@ -110,6 +136,21 @@ pub fn to_bundle(seed: CaseSeed) -> CaseBundle {
     CaseBundle {
         seed: mutated,
         signature,
+        environment: None,
+        failure_payload: Vec::new(),
+    }
+}
+
+/// Like [`to_bundle`], but attaches [`EnvironmentFingerprint::capture`] for replay checks.
+pub fn to_bundle_with_environment(seed: CaseSeed) -> CaseBundle {
+    let environment = Some(EnvironmentFingerprint::capture());
+    let mutated = mutate_seed(&seed);
+    let signature = classify(&mutated);
+    CaseBundle {
+        seed: mutated,
+        signature,
+        environment,
+        failure_payload: Vec::new(),
     }
 }
 
@@ -146,6 +187,38 @@ mod tests {
         };
         let bundle = to_bundle(seed);
         assert!(!bundle.signature.category.is_empty());
+    }
+
+    #[test]
+    fn to_bundle_has_no_environment_by_default() {
+        let bundle = to_bundle(CaseSeed {
+            id: 1,
+            payload: vec![1],
+        });
+        assert!(bundle.environment.is_none());
+    }
+
+    #[test]
+    fn to_bundle_with_environment_captures_fingerprint() {
+        let bundle = to_bundle_with_environment(CaseSeed {
+            id: 1,
+            payload: vec![1],
+        });
+        let fp = bundle.environment.as_ref().expect("fingerprint");
+        assert_eq!(fp.os, std::env::consts::OS);
+        assert_eq!(fp.arch, std::env::consts::ARCH);
+    }
+
+    #[test]
+    fn replay_environment_report_clean_when_capture_matches_bundle() {
+        let bundle = to_bundle_with_environment(CaseSeed {
+            id: 1,
+            payload: vec![1, 2, 3],
+        });
+        let current = EnvironmentFingerprint::capture();
+        let report = bundle.replay_environment_report(&current);
+        assert!(!report.material_mismatch);
+        assert!(report.warnings.is_empty());
     }
 
     // ── signature_hash stability ──────────────────────────────────────────────

--- a/contracts/crashlab-core/src/reproducer.rs
+++ b/contracts/crashlab-core/src/reproducer.rs
@@ -126,7 +126,7 @@ mod tests {
 
     fn divergent_sig() -> CrashSignature {
         CrashSignature {
-            category: "runtime-failure",
+            category: "runtime-failure".to_string(),
             digest: 0xDEAD_BEEF,
             signature_hash: 0xDEAD_BEEF_CAFE_0000,
         }


### PR DESCRIPTION
- Add bundle_persist: CaseBundleDocument with schema field, save/load helpers
- serde on CaseSeed, CrashSignature, EnvironmentFingerprint; category is String
- CaseBundle: environment + failure_payload; restore env_fingerprint module
- to_bundle_with_environment; replay_environment_report on CaseBundle
- BundlePersistError: Json, Io, UnsupportedSchema
- README: persistence usage; dev-deps serde/serde_json