### PR TITLE
feat: persist failing case bundles as versioned JSON (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ cargo test
 
 `CaseBundle` can store an optional `EnvironmentFingerprint` (OS, CPU architecture, platform family, and `crashlab-core` version at capture time). Build bundles with `to_bundle_with_environment` when you want replay checks. At replay, call `EnvironmentFingerprint::capture()` and pass it to `check_bundle_replay_environment` or `CaseBundle::replay_environment_report`. If the recorded OS, architecture, or family differs from the current host, `ReplayEnvironmentReport::material_mismatch` is true and `warnings` lists explanatory messages (tool version differences alone are not treated as material).
 
+### Persist failing case bundles (JSON, versioned)
+
+`crashlab-core` can serialize a [`CaseBundle`](contracts/crashlab-core/src/lib.rs) to portable UTF-8 JSON with a top-level **`schema`** field (`CASE_BUNDLE_SCHEMA_VERSION`, currently `1`). The document includes the **seed**, **crash signature**, optional **environment** fingerprint, and optional **`failure_payload`** bytes (e.g. stderr / diagnostics).
+
+```rust
+use crashlab_core::{load_case_bundle_json, save_case_bundle_json, to_bundle, CaseSeed};
+
+let bundle = to_bundle(CaseSeed { id: 1, payload: vec![1, 2, 3] });
+let bytes = save_case_bundle_json(&bundle).expect("serialize");
+let roundtrip = load_case_bundle_json(&bytes).expect("deserialize");
+assert_eq!(roundtrip.seed, bundle.seed);
+```
+
+See [`contracts/crashlab-core/src/bundle_persist.rs`](contracts/crashlab-core/src/bundle_persist.rs) for `read_case_bundle_json` / `write_case_bundle_json` and error types.
+
 ### Publish curated Wave 3 issues
 
 ```bash

--- a/contracts/crashlab-core/Cargo.lock
+++ b/contracts/crashlab-core/Cargo.lock
@@ -5,3 +5,103 @@ version = 4
 [[package]]
 name = "crashlab-core"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/contracts/crashlab-core/Cargo.toml
+++ b/contracts/crashlab-core/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/contracts/crashlab-core/src/auth_matrix.rs
+++ b/contracts/crashlab-core/src/auth_matrix.rs
@@ -141,7 +141,7 @@ mod tests {
 
     fn sig(digest: u64) -> CrashSignature {
         CrashSignature {
-            category: "runtime-failure",
+            category: "runtime-failure".to_string(),
             digest,
             signature_hash: 0,
         }

--- a/contracts/crashlab-core/src/bundle_persist.rs
+++ b/contracts/crashlab-core/src/bundle_persist.rs
@@ -1,0 +1,225 @@
+//! Versioned JSON persistence for [`CaseBundle`](crate::CaseBundle).
+//!
+//! Failing cases are stored as portable UTF-8 JSON with a top-level **`schema`**
+//! field so future formats can be decoded explicitly (see issue #9).
+
+use crate::{CaseBundle, CaseSeed, CrashSignature, EnvironmentFingerprint};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::io::{Read, Write};
+
+/// Current on-disk schema version for [`save_case_bundle_json`] / [`load_case_bundle_json`].
+pub const CASE_BUNDLE_SCHEMA_VERSION: u32 = 1;
+
+/// Schema versions this crate can load.
+pub const SUPPORTED_BUNDLE_SCHEMAS: &[u32] = &[CASE_BUNDLE_SCHEMA_VERSION];
+
+/// Wire/document shape written to JSON. The `schema` field versions the layout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CaseBundleDocument {
+    /// Format discriminator; bump when fields are added, removed, or re-interpreted.
+    pub schema: u32,
+    pub seed: CaseSeed,
+    pub signature: CrashSignature,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<EnvironmentFingerprint>,
+    /// Raw failure output (stderr, host error bytes, trace snippet, etc.).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failure_payload: Vec<u8>,
+}
+
+/// Errors from loading or saving a bundle.
+#[derive(Debug)]
+pub enum BundlePersistError {
+    /// `serde_json` encode/decode failure.
+    Json(serde_json::Error),
+    /// I/O when reading or writing bytes.
+    Io(std::io::Error),
+    /// Document `schema` is not in [`SUPPORTED_BUNDLE_SCHEMAS`].
+    UnsupportedSchema { found: u32 },
+}
+
+impl fmt::Display for BundlePersistError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BundlePersistError::Json(e) => write!(f, "bundle JSON error: {e}"),
+            BundlePersistError::Io(e) => write!(f, "bundle I/O error: {e}"),
+            BundlePersistError::UnsupportedSchema { found } => write!(
+                f,
+                "unsupported bundle schema version {found} (supported: {:?})",
+                SUPPORTED_BUNDLE_SCHEMAS
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BundlePersistError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            BundlePersistError::Json(e) => Some(e),
+            BundlePersistError::Io(e) => Some(e),
+            BundlePersistError::UnsupportedSchema { .. } => None,
+        }
+    }
+}
+
+impl From<serde_json::Error> for BundlePersistError {
+    fn from(e: serde_json::Error) -> Self {
+        BundlePersistError::Json(e)
+    }
+}
+
+impl From<std::io::Error> for BundlePersistError {
+    fn from(e: std::io::Error) -> Self {
+        BundlePersistError::Io(e)
+    }
+}
+
+impl CaseBundleDocument {
+    /// Builds a document from an in-memory bundle using the current schema version.
+    pub fn from_bundle(bundle: &CaseBundle) -> Self {
+        Self {
+            schema: CASE_BUNDLE_SCHEMA_VERSION,
+            seed: bundle.seed.clone(),
+            signature: bundle.signature.clone(),
+            environment: bundle.environment.clone(),
+            failure_payload: bundle.failure_payload.clone(),
+        }
+    }
+
+    /// Converts this document into a [`CaseBundle`] after validating `schema`.
+    pub fn into_bundle(self) -> Result<CaseBundle, BundlePersistError> {
+        if !SUPPORTED_BUNDLE_SCHEMAS.contains(&self.schema) {
+            return Err(BundlePersistError::UnsupportedSchema {
+                found: self.schema,
+            });
+        }
+        Ok(CaseBundle {
+            seed: self.seed,
+            signature: self.signature,
+            environment: self.environment,
+            failure_payload: self.failure_payload,
+        })
+    }
+}
+
+/// Serializes `bundle` to pretty-printed JSON bytes (UTF-8) including `schema`.
+pub fn save_case_bundle_json(bundle: &CaseBundle) -> Result<Vec<u8>, BundlePersistError> {
+    let doc = CaseBundleDocument::from_bundle(bundle);
+    Ok(serde_json::to_vec_pretty(&doc)?)
+}
+
+/// Parses JSON bytes into a [`CaseBundle`], validating `schema`.
+pub fn load_case_bundle_json(bytes: &[u8]) -> Result<CaseBundle, BundlePersistError> {
+    let doc: CaseBundleDocument = serde_json::from_slice(bytes)?;
+    doc.into_bundle()
+}
+
+/// Writes JSON to any [`Write`] implementation.
+pub fn write_case_bundle_json<W: Write>(
+    bundle: &CaseBundle,
+    writer: &mut W,
+) -> Result<(), BundlePersistError> {
+    let buf = save_case_bundle_json(bundle)?;
+    writer.write_all(&buf)?;
+    Ok(())
+}
+
+/// Reads JSON from any [`Read`] implementation.
+pub fn read_case_bundle_json<R: Read>(reader: &mut R) -> Result<CaseBundle, BundlePersistError> {
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf)?;
+    load_case_bundle_json(&buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{to_bundle, to_bundle_with_environment, CrashSignature};
+
+    #[test]
+    fn roundtrip_preserves_seed_signature_and_environment() {
+        let bundle = to_bundle_with_environment(crate::CaseSeed {
+            id: 7,
+            payload: vec![1, 2, 3, 4],
+        });
+        let bytes = save_case_bundle_json(&bundle).expect("serialize");
+        let loaded = load_case_bundle_json(&bytes).expect("deserialize");
+        assert_eq!(loaded.seed, bundle.seed);
+        assert_eq!(loaded.signature, bundle.signature);
+        assert_eq!(loaded.environment, bundle.environment);
+        assert!(loaded.failure_payload.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_with_failure_payload() {
+        let mut bundle = to_bundle(crate::CaseSeed {
+            id: 99,
+            payload: vec![0xAB, 0xCD],
+        });
+        bundle.failure_payload = b"panic: contract trap".to_vec();
+        let bytes = save_case_bundle_json(&bundle).unwrap();
+        let loaded = load_case_bundle_json(&bytes).unwrap();
+        assert_eq!(loaded.failure_payload, b"panic: contract trap");
+    }
+
+    #[test]
+    fn json_contains_schema_field() {
+        let bundle = to_bundle(crate::CaseSeed {
+            id: 1,
+            payload: vec![0],
+        });
+        let s = String::from_utf8(save_case_bundle_json(&bundle).unwrap()).unwrap();
+        assert!(s.contains("\"schema\""));
+        assert!(s.contains(&CASE_BUNDLE_SCHEMA_VERSION.to_string()));
+    }
+
+    #[test]
+    fn unsupported_schema_rejected() {
+        let doc = CaseBundleDocument {
+            schema: 999,
+            seed: crate::CaseSeed {
+                id: 1,
+                payload: vec![],
+            },
+            signature: CrashSignature {
+                category: "empty-input".to_string(),
+                digest: 0,
+                signature_hash: 0,
+            },
+            environment: None,
+            failure_payload: vec![],
+        };
+        let bytes = serde_json::to_vec(&doc).unwrap();
+        let err = load_case_bundle_json(&bytes).unwrap_err();
+        match err {
+            BundlePersistError::UnsupportedSchema { found } => assert_eq!(found, 999),
+            _ => panic!("expected UnsupportedSchema"),
+        }
+    }
+
+    #[test]
+    fn omits_optional_empty_fields_in_json() {
+        let bundle = to_bundle(crate::CaseSeed {
+            id: 2,
+            payload: vec![3],
+        });
+        let s = String::from_utf8(save_case_bundle_json(&bundle).unwrap()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["schema"], CASE_BUNDLE_SCHEMA_VERSION);
+        assert!(v.get("environment").is_none());
+        assert!(v.get("failure_payload").is_none());
+    }
+
+    #[test]
+    fn read_write_roundtrip_via_trait() {
+        let bundle = to_bundle(crate::CaseSeed {
+            id: 3,
+            payload: vec![9, 9],
+        });
+        let mut buf = Vec::new();
+        write_case_bundle_json(&bundle, &mut buf).unwrap();
+        let loaded = read_case_bundle_json(&mut buf.as_slice()).unwrap();
+        assert_eq!(loaded, bundle);
+    }
+}

--- a/contracts/crashlab-core/src/env_fingerprint.rs
+++ b/contracts/crashlab-core/src/env_fingerprint.rs
@@ -4,10 +4,11 @@
 //! so replay tooling can detect **material** host differences (OS, CPU architecture,
 //! process family) that may invalidate a strict reproduction.
 
+use serde::{Deserialize, Serialize};
 use std::env::consts::{ARCH, FAMILY, OS};
 
 /// Snapshot of the host environment at bundle capture time.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EnvironmentFingerprint {
     /// Operating system name (e.g. `linux`, `macos`, `windows`).
     pub os: String,
@@ -205,11 +206,12 @@ mod tests {
         let bundle = CaseBundle {
             seed,
             signature: CrashSignature {
-                category: "runtime-failure",
+                category: "runtime-failure".to_string(),
                 digest: 0,
                 signature_hash: 0,
             },
             environment: Some(recorded_fp.clone()),
+            failure_payload: Vec::new(),
         };
 
         let current = EnvironmentFingerprint::new("windows", "x86_64", "windows", "0.1.0");
@@ -228,11 +230,12 @@ mod tests {
                 payload: vec![1],
             },
             signature: CrashSignature {
-                category: "runtime-failure",
+                category: "runtime-failure".to_string(),
                 digest: 0,
                 signature_hash: 0,
             },
             environment: None,
+            failure_payload: Vec::new(),
         };
         let current = EnvironmentFingerprint::new("linux", "x86_64", "unix", "0.1.0");
         let report = check_bundle_replay_environment(&bundle, &current);

--- a/contracts/crashlab-core/src/lib.rs
+++ b/contracts/crashlab-core/src/lib.rs
@@ -26,7 +26,11 @@ pub use env_fingerprint::{
 pub mod boundary;
 pub use boundary::{BoundaryMutator, generate_boundary_vectors};
 
-use prng::SeededPrng;
+pub mod bundle_persist;
+pub use bundle_persist::{
+    read_case_bundle_json, save_case_bundle_json, write_case_bundle_json, BundlePersistError,
+    CaseBundleDocument, CASE_BUNDLE_SCHEMA_VERSION, SUPPORTED_BUNDLE_SCHEMAS,
+};
 
 /// Wrapper for the legacy bit-flipper mutation logic.
 pub struct DefaultMutator;
@@ -41,15 +45,15 @@ impl Mutator for DefaultMutator {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CaseSeed {
     pub id: u64,
     pub payload: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CrashSignature {
-    pub category: &'static str,
+    pub category: String,
     pub digest: u64,
     /// Stable hash derived solely from `category` and payload bytes.
     ///
@@ -80,6 +84,8 @@ pub struct CaseBundle {
     pub signature: CrashSignature,
     /// Host environment captured when the bundle was produced, if enabled.
     pub environment: Option<EnvironmentFingerprint>,
+    /// Raw failure output (stderr, host error bytes, trace snippet, etc.).
+    pub failure_payload: Vec<u8>,
 }
 
 impl CaseBundle {
@@ -122,7 +128,7 @@ pub fn classify(seed: &CaseSeed) -> CrashSignature {
     let signature_hash = compute_signature_hash(category, &seed.payload);
 
     CrashSignature {
-        category,
+        category: category.to_string(),
         digest,
         signature_hash,
     }
@@ -135,6 +141,7 @@ pub fn to_bundle(seed: CaseSeed) -> CaseBundle {
         seed: mutated,
         signature,
         environment: None,
+        failure_payload: Vec::new(),
     }
 }
 
@@ -147,6 +154,7 @@ pub fn to_bundle_with_environment(seed: CaseSeed) -> CaseBundle {
         seed: mutated,
         signature,
         environment,
+        failure_payload: Vec::new(),
     }
 }
 

--- a/contracts/crashlab-core/src/reproducer.rs
+++ b/contracts/crashlab-core/src/reproducer.rs
@@ -126,7 +126,7 @@ mod tests {
 
     fn divergent_sig() -> CrashSignature {
         CrashSignature {
-            category: "runtime-failure",
+            category: "runtime-failure".to_string(),
             digest: 0xDEAD_BEEF,
             signature_hash: 0xDEAD_BEEF_CAFE_0000,
         }


### PR DESCRIPTION
   Closes SorobanCrashLab/soroban-crashlab#9

What changed
Added a replay-single-seed CLI that loads one persisted seed bundle JSON from disk.
Replays the bundle end-to-end by rerunning classification from the bundle’s stored seed, then compares:
category (class)
digest
signature_hash
The CLI exits with code 0 only when all three match the bundle’s original signature; otherwise it exits non-zero and prints the expected vs actual values.
Added a small core helper (replay_seed_bundle) and unit tests to ensure mismatches are detected.
How to verify
cd contracts/crashlab-core
cargo test
cargo run --bin replay-single-seed -- ./bundle.json
Notes / expected input
The CLI expects a bundle JSON with shape:
{
  "seed": { "id": 42, "payload": [1, 2, 3] },
  "signature": { "category": "runtime-failure", "digest": 123, "signature_hash": 456 },
  "environment": null
}