### PR TITLE
[48] Implement run resume from checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ cd contracts/crashlab-core
 cargo test
 ```
 
+### Run checkpoints (resume without redoing work)
+
+Persist a [`RunCheckpoint`](contracts/crashlab-core/src/checkpoint.rs) (JSON) with `next_seed_index` and reload it after an interruption. Use `RunCheckpoint::remaining(&seeds)` to iterate only pending seeds, and `advance_one` / `advance_by` after each completed item so resumed runs skip finished work.
+
+### Corpus export (portable seed archive)
+
+Export a deterministic, sorted corpus JSON (schema `CORPUS_ARCHIVE_SCHEMA_VERSION`) via `export_corpus_json` / `import_corpus_json`, or the CLI:
+
+```bash
+cd contracts/crashlab-core
+cargo run --bin export-corpus -- seeds.json > corpus-archive.json
+```
+
+Input may be a bare JSON array of seeds or a full archive document; output is always canonical sorted order for stable sharing and re-import.
+
+### Simulation timeout guardrails
+
+`run_simulation_with_timeout` wraps a host/contract simulation and returns `timeout_crash_signature` when wall time exceeds `SimulationTimeoutConfig::timeout_ms`. Surface the active limit in dashboards or logs with `RunMetadata::from_timeout_config`.
+
+### Vec / map container stress mutator
+
+[`ContainerStressMutator`](contracts/crashlab-core/src/container_stress.rs) encodes bounded vec vs map growth and sparse key stride into a 32-byte payload (configurable min/max per dimension). Register it with [`WeightedScheduler`](contracts/crashlab-core/src/scheduler.rs) alongside other mutators.
+
 ### Failing-case bundles and replay environment
 
 `CaseBundle` can store an optional `EnvironmentFingerprint` (OS, CPU architecture, platform family, and `crashlab-core` version at capture time). Build bundles with `to_bundle_with_environment` when you want replay checks. At replay, call `EnvironmentFingerprint::capture()` and pass it to `check_bundle_replay_environment` or `CaseBundle::replay_environment_report`. If the recorded OS, architecture, or family differs from the current host, `ReplayEnvironmentReport::material_mismatch` is true and `warnings` lists explanatory messages (tool version differences alone are not treated as material).

--- a/contracts/crashlab-core/Cargo.toml
+++ b/contracts/crashlab-core/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2024"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[[bin]]
+name = "export-corpus"
+path = "src/bin/export-corpus.rs"

--- a/contracts/crashlab-core/src/bin/export-corpus.rs
+++ b/contracts/crashlab-core/src/bin/export-corpus.rs
@@ -1,0 +1,58 @@
+//! CLI: export a seed list to a canonical corpus archive JSON on stdout.
+//!
+//! Input (file path argument or stdin): either a JSON array of [`CaseSeed`]
+//! objects or a full [`CorpusArchive`] document. Output is always a sorted
+//! [`CorpusArchive`] matching [`CORPUS_ARCHIVE_SCHEMA_VERSION`].
+
+use crashlab_core::corpus::{export_corpus_json, import_corpus_json};
+use crashlab_core::CaseSeed;
+use std::env;
+use std::fs;
+use std::io::{self, Read, Write};
+use std::process;
+
+fn main() {
+    let input_bytes = read_input();
+    let seeds = parse_seeds(&input_bytes).unwrap_or_else(|e| {
+        eprintln!("{e}");
+        process::exit(1);
+    });
+    let out = export_corpus_json(&seeds).unwrap_or_else(|e| {
+        eprintln!("serialize: {e}");
+        process::exit(1);
+    });
+    io::stdout()
+        .write_all(&out)
+        .unwrap_or_else(|e| {
+            eprintln!("write: {e}");
+            process::exit(1);
+        });
+}
+
+fn read_input() -> Vec<u8> {
+    let mut args = env::args();
+    let _ = args.next();
+    if let Some(path) = args.next() {
+        fs::read(&path).unwrap_or_else(|e| {
+            eprintln!("read {path}: {e}");
+            process::exit(1);
+        })
+    } else {
+        let mut buf = Vec::new();
+        io::stdin().read_to_end(&mut buf).unwrap_or_else(|e| {
+            eprintln!("stdin: {e}");
+            process::exit(1);
+        });
+        buf
+    }
+}
+
+fn parse_seeds(bytes: &[u8]) -> Result<Vec<CaseSeed>, String> {
+    if bytes.is_empty() {
+        return Err("empty input".into());
+    }
+    if let Ok(seeds) = import_corpus_json(bytes) {
+        return Ok(seeds);
+    }
+    serde_json::from_slice::<Vec<CaseSeed>>(bytes).map_err(|e| format!("parse seeds: {e}"))
+}

--- a/contracts/crashlab-core/src/checkpoint.rs
+++ b/contracts/crashlab-core/src/checkpoint.rs
@@ -1,0 +1,184 @@
+//! Campaign run checkpoints for resuming interrupted fuzzing without redoing work.
+//!
+//! Persist [`RunCheckpoint`] as JSON and reload before continuing a campaign.
+//! The checkpoint records the next seed index to process; seeds with indices
+//! `< next_seed_index` are treated as already completed.
+
+use crate::CaseSeed;
+use serde::{Deserialize, Serialize};
+
+/// Schema version for [`RunCheckpoint`] JSON on disk.
+pub const RUN_CHECKPOINT_SCHEMA_VERSION: u32 = 1;
+
+/// Serializable checkpoint for a single campaign run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunCheckpoint {
+    /// Format discriminator; bump when fields change meaning.
+    pub schema: u32,
+    /// Stable identifier for the campaign (caller-defined).
+    pub campaign_id: String,
+    /// Index into the original seed schedule; seeds `[0..next_seed_index)` are done.
+    pub next_seed_index: usize,
+    /// Total seeds in the schedule when the checkpoint was written (for validation).
+    pub total_seeds: usize,
+}
+
+/// Errors when applying a checkpoint to a seed slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckpointError {
+    /// `next_seed_index` is past the end of the provided slice.
+    IndexPastEnd {
+        next_seed_index: usize,
+        seeds_len: usize,
+    },
+    /// Recorded `total_seeds` does not match `seeds.len()`.
+    TotalMismatch { recorded: usize, actual: usize },
+}
+
+impl std::fmt::Display for CheckpointError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CheckpointError::IndexPastEnd {
+                next_seed_index,
+                seeds_len,
+            } => write!(
+                f,
+                "checkpoint next_seed_index {next_seed_index} is beyond seeds length {seeds_len}"
+            ),
+            CheckpointError::TotalMismatch { recorded, actual } => write!(
+                f,
+                "checkpoint total_seeds {recorded} does not match actual schedule length {actual}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CheckpointError {}
+
+impl RunCheckpoint {
+    /// Starts a fresh checkpoint at the beginning of `seeds`.
+    pub fn new_run(campaign_id: impl Into<String>, seeds: &[CaseSeed]) -> Self {
+        Self {
+            schema: RUN_CHECKPOINT_SCHEMA_VERSION,
+            campaign_id: campaign_id.into(),
+            next_seed_index: 0,
+            total_seeds: seeds.len(),
+        }
+    }
+
+    /// Seeds still to process, or an error if the checkpoint does not match `seeds`.
+    pub fn remaining<'a>(
+        &self,
+        seeds: &'a [CaseSeed],
+    ) -> Result<&'a [CaseSeed], CheckpointError> {
+        if self.total_seeds != seeds.len() {
+            return Err(CheckpointError::TotalMismatch {
+                recorded: self.total_seeds,
+                actual: seeds.len(),
+            });
+        }
+        if self.next_seed_index > seeds.len() {
+            return Err(CheckpointError::IndexPastEnd {
+                next_seed_index: self.next_seed_index,
+                seeds_len: seeds.len(),
+            });
+        }
+        Ok(&seeds[self.next_seed_index..])
+    }
+
+    /// Marks one seed as completed (advances by one).
+    pub fn advance_one(&mut self) {
+        self.next_seed_index = self.next_seed_index.saturating_add(1);
+    }
+
+    /// Marks `n` seeds as completed.
+    pub fn advance_by(&mut self, n: usize) {
+        self.next_seed_index = self.next_seed_index.saturating_add(n);
+    }
+
+    /// True when every seed in the schedule has been processed.
+    pub fn is_complete(&self, seeds: &[CaseSeed]) -> bool {
+        seeds.len() == self.total_seeds && self.next_seed_index >= self.total_seeds
+    }
+}
+
+/// Serializes a checkpoint to pretty JSON bytes.
+pub fn save_run_checkpoint_json(cp: &RunCheckpoint) -> Result<Vec<u8>, serde_json::Error> {
+    serde_json::to_vec_pretty(cp)
+}
+
+/// Parses a checkpoint from JSON bytes.
+pub fn load_run_checkpoint_json(bytes: &[u8]) -> Result<RunCheckpoint, serde_json::Error> {
+    serde_json::from_slice(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seeds(n: usize) -> Vec<CaseSeed> {
+        (0..n)
+            .map(|i| CaseSeed {
+                id: i as u64,
+                payload: vec![i as u8],
+            })
+            .collect()
+    }
+
+    #[test]
+    fn fresh_checkpoint_starts_at_zero() {
+        let s = seeds(10);
+        let cp = RunCheckpoint::new_run("c1", &s);
+        assert_eq!(cp.next_seed_index, 0);
+        assert_eq!(cp.total_seeds, 10);
+        assert_eq!(cp.remaining(&s).unwrap().len(), 10);
+    }
+
+    #[test]
+    fn advance_skips_completed_prefix() {
+        let s = seeds(10);
+        let mut cp = RunCheckpoint::new_run("c1", &s);
+        cp.advance_by(3);
+        assert_eq!(cp.remaining(&s).unwrap().len(), 7);
+        assert_eq!(cp.remaining(&s).unwrap()[0].id, 3);
+    }
+
+    #[test]
+    fn resume_does_not_reprocess_completed() {
+        let s = seeds(5);
+        let mut cp = RunCheckpoint::new_run("c1", &s);
+        cp.advance_by(3);
+        let rest = cp.remaining(&s).unwrap();
+        let ids: Vec<u64> = rest.iter().map(|x| x.id).collect();
+        assert_eq!(ids, vec![3, 4]);
+    }
+
+    #[test]
+    fn total_mismatch_errors() {
+        let s = seeds(5);
+        let mut cp = RunCheckpoint::new_run("c1", &s);
+        cp.total_seeds = 99;
+        assert!(matches!(
+            cp.remaining(&s),
+            Err(CheckpointError::TotalMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn json_roundtrip() {
+        let s = seeds(4);
+        let mut cp = RunCheckpoint::new_run("wave3", &s);
+        cp.advance_by(2);
+        let bytes = save_run_checkpoint_json(&cp).unwrap();
+        let loaded = load_run_checkpoint_json(&bytes).unwrap();
+        assert_eq!(loaded, cp);
+    }
+
+    #[test]
+    fn is_complete_when_fully_advanced() {
+        let s = seeds(3);
+        let mut cp = RunCheckpoint::new_run("c", &s);
+        cp.advance_by(3);
+        assert!(cp.is_complete(&s));
+    }
+}

--- a/contracts/crashlab-core/src/container_stress.rs
+++ b/contracts/crashlab-core/src/container_stress.rs
@@ -1,0 +1,238 @@
+//! Vec / map size stress mutator for host container inputs.
+//!
+//! Encodes a mode (vector vs map), bounded sizes, and a sparse key stride into a
+//! compact payload. Sizes are clamped to configured min/max bounds; generation is
+//! deterministic from `(seed, rng_state)` like other mutators.
+
+use crate::CaseSeed;
+use crate::scheduler::Mutator;
+
+/// Bounds for encoded container dimensions (inclusive).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContainerStressConfig {
+    pub vec_size_min: u64,
+    pub vec_size_max: u64,
+    pub map_size_min: u64,
+    pub map_size_max: u64,
+}
+
+impl Default for ContainerStressConfig {
+    fn default() -> Self {
+        Self {
+            vec_size_min: 0,
+            vec_size_max: 256,
+            map_size_min: 0,
+            map_size_max: 128,
+        }
+    }
+}
+
+impl ContainerStressConfig {
+    pub fn new(
+        vec_size_min: u64,
+        vec_size_max: u64,
+        map_size_min: u64,
+        map_size_max: u64,
+    ) -> Self {
+        Self {
+            vec_size_min,
+            vec_size_max,
+            map_size_min,
+            map_size_max,
+        }
+    }
+
+    fn clamp(&self, v: u64, min: u64, max: u64) -> u64 {
+        if max < min {
+            return min;
+        }
+        v.min(max).max(min)
+    }
+
+    fn pick_in_range(&self, rng: &mut u64, min: u64, max: u64) -> u64 {
+        advance_rng(rng);
+        if max <= min {
+            return min;
+        }
+        let span = max - min + 1;
+        let pick = *rng % span;
+        min + pick
+    }
+}
+
+/// Mutator that stresses Soroban-style vec growth vs sparse map key patterns.
+pub struct ContainerStressMutator {
+    pub config: ContainerStressConfig,
+}
+
+impl ContainerStressMutator {
+    pub fn new(config: ContainerStressConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn default_mutator() -> Self {
+        Self::new(ContainerStressConfig::default())
+    }
+}
+
+/// Payload layout (32 bytes, within default 64-byte seed cap):
+/// - `[0]` mode: `0xD0` vec, `0xD1` map
+/// - `[1..9]` primary size (`u64` LE), meaning vec length or map entry count
+/// - `[9..17]` secondary (`u64` LE) — companion bound or sparse stride
+/// - `[17..32]` pattern fill derived from rng
+fn build_payload(
+    config: &ContainerStressConfig,
+    seed: &CaseSeed,
+    rng_state: &mut u64,
+) -> Vec<u8> {
+    let use_map = (*rng_state ^ seed.id) & 1 == 1;
+    let vec_sz = config.pick_in_range(
+        rng_state,
+        config.vec_size_min,
+        config.vec_size_max,
+    );
+    let map_sz = config.pick_in_range(
+        rng_state,
+        config.map_size_min,
+        config.map_size_max,
+    );
+    let stride = config.pick_in_range(rng_state, 1, map_sz.max(1));
+
+    let mut out = vec![0u8; 32];
+    if use_map {
+        out[0] = 0xD1;
+        let primary = config.clamp(map_sz, config.map_size_min, config.map_size_max);
+        let secondary = config.clamp(stride, 1, u64::max(map_sz, 1));
+        out[1..9].copy_from_slice(&primary.to_le_bytes());
+        out[9..17].copy_from_slice(&secondary.to_le_bytes());
+    } else {
+        out[0] = 0xD0;
+        let primary = config.clamp(vec_sz, config.vec_size_min, config.vec_size_max);
+        let secondary =
+            config.clamp(vec_sz.wrapping_add(map_sz), config.vec_size_min, config.vec_size_max);
+        out[1..9].copy_from_slice(&primary.to_le_bytes());
+        out[9..17].copy_from_slice(&secondary.to_le_bytes());
+    }
+
+    for i in 17..32 {
+        advance_rng(rng_state);
+        out[i] = (*rng_state ^ seed.id.wrapping_add(i as u64)) as u8;
+    }
+
+    out
+}
+
+fn advance_rng(state: &mut u64) {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    *state = z ^ (z >> 31);
+}
+
+impl Mutator for ContainerStressMutator {
+    fn name(&self) -> &'static str {
+        "container-stress"
+    }
+
+    fn mutate(&self, seed: &CaseSeed, rng_state: &mut u64) -> CaseSeed {
+        CaseSeed {
+            id: seed.id,
+            payload: build_payload(&self.config, seed, rng_state),
+        }
+    }
+}
+
+/// Deterministic [`CaseSeed`] grid across config bounds (for corpus / tests).
+pub fn generate_container_stress_grid(
+    base_id: u64,
+    config: &ContainerStressConfig,
+) -> Vec<CaseSeed> {
+    let mut out = Vec::new();
+    let mut id = base_id;
+    let v_steps = config.vec_size_max.saturating_sub(config.vec_size_min).min(8);
+    let m_steps = config.map_size_max.saturating_sub(config.map_size_min).min(8);
+
+    for vi in 0..=v_steps {
+        for mi in 0..=m_steps {
+            let v = config.vec_size_min + vi;
+            let m = config.map_size_min + mi;
+            let mut payload = vec![0u8; 32];
+            payload[0] = 0xD0;
+            payload[1..9].copy_from_slice(&v.to_le_bytes());
+            payload[9..17].copy_from_slice(&m.to_le_bytes());
+            for i in 17..32 {
+                payload[i] = (id.wrapping_add(i as u64) ^ vi as u64 ^ mi as u64) as u8;
+            }
+            out.push(CaseSeed { id, payload });
+            id += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mutator_name() {
+        assert_eq!(ContainerStressMutator::default_mutator().name(), "container-stress");
+    }
+
+    #[test]
+    fn deterministic_for_same_inputs() {
+        let m = ContainerStressMutator::default_mutator();
+        let seed = CaseSeed {
+            id: 10,
+            payload: vec![1, 2, 3],
+        };
+        let a = m.mutate(&seed, &mut 99u64);
+        let b = m.mutate(&seed, &mut 99u64);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn respects_vec_bounds() {
+        let cfg = ContainerStressConfig::new(5, 10, 0, 2);
+        let m = ContainerStressMutator::new(cfg);
+        let seed = CaseSeed {
+            id: 1,
+            payload: vec![0xFF; 40],
+        };
+        for r in 0..50u64 {
+            let mut rng = r;
+            let out = m.mutate(&seed, &mut rng);
+            if out.payload[0] == 0xD0 {
+                let vec_sz = u64::from_le_bytes(out.payload[1..9].try_into().unwrap());
+                assert!(vec_sz >= 5 && vec_sz <= 10);
+            }
+        }
+    }
+
+    #[test]
+    fn respects_map_bounds() {
+        let cfg = ContainerStressConfig::new(0, 1, 20, 30);
+        let m = ContainerStressMutator::new(cfg);
+        let seed = CaseSeed {
+            id: 2,
+            payload: vec![0xAB; 20],
+        };
+        for r in 0..80u64 {
+            let mut rng = r.wrapping_mul(0xFFFF);
+            let out = m.mutate(&seed, &mut rng);
+            if out.payload[0] == 0xD1 {
+                let map_sz = u64::from_le_bytes(out.payload[1..9].try_into().unwrap());
+                assert!(map_sz >= 20 && map_sz <= 30);
+            }
+        }
+    }
+
+    #[test]
+    fn grid_is_deterministic() {
+        let cfg = ContainerStressConfig::new(1, 3, 1, 3);
+        let a = generate_container_stress_grid(100, &cfg);
+        let b = generate_container_stress_grid(100, &cfg);
+        assert_eq!(a, b);
+    }
+}

--- a/contracts/crashlab-core/src/corpus.rs
+++ b/contracts/crashlab-core/src/corpus.rs
@@ -1,0 +1,138 @@
+//! Portable corpus (seed list) export and import with stable ordering.
+//!
+//! Seeds are sorted deterministically by `(id, payload)` before serialization so
+//! archives round-trip and merge predictably.
+
+use crate::CaseSeed;
+use serde::{Deserialize, Serialize};
+
+/// Schema version for [`CorpusArchive`] JSON.
+pub const CORPUS_ARCHIVE_SCHEMA_VERSION: u32 = 1;
+
+/// Versioned corpus document for sharing seed sets between hosts and CI.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusArchive {
+    pub schema: u32,
+    pub seeds: Vec<CaseSeed>,
+}
+
+/// Errors from loading a corpus archive.
+#[derive(Debug)]
+pub enum CorpusError {
+    Json(serde_json::Error),
+    UnsupportedSchema { found: u32 },
+}
+
+impl std::fmt::Display for CorpusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CorpusError::Json(e) => write!(f, "corpus JSON error: {e}"),
+            CorpusError::UnsupportedSchema { found } => {
+                write!(f, "unsupported corpus schema version {found}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CorpusError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CorpusError::Json(e) => Some(e),
+            CorpusError::UnsupportedSchema { .. } => None,
+        }
+    }
+}
+
+impl From<serde_json::Error> for CorpusError {
+    fn from(e: serde_json::Error) -> Self {
+        CorpusError::Json(e)
+    }
+}
+
+fn sort_seeds_deterministic(seeds: &mut [CaseSeed]) {
+    seeds.sort_by(|a, b| {
+        a.id
+            .cmp(&b.id)
+            .then_with(|| a.payload.cmp(&b.payload))
+    });
+}
+
+/// Builds an archive from arbitrary seed order; output order is deterministic.
+pub fn corpus_archive_from_seeds(mut seeds: Vec<CaseSeed>) -> CorpusArchive {
+    sort_seeds_deterministic(&mut seeds);
+    CorpusArchive {
+        schema: CORPUS_ARCHIVE_SCHEMA_VERSION,
+        seeds,
+    }
+}
+
+/// Serializes a corpus to pretty JSON bytes.
+pub fn export_corpus_json(seeds: &[CaseSeed]) -> Result<Vec<u8>, serde_json::Error> {
+    let arch = corpus_archive_from_seeds(seeds.to_vec());
+    serde_json::to_vec_pretty(&arch)
+}
+
+/// Parses JSON into a corpus and validates `schema`.
+pub fn import_corpus_json(bytes: &[u8]) -> Result<Vec<CaseSeed>, CorpusError> {
+    let arch: CorpusArchive = serde_json::from_slice(bytes)?;
+    if arch.schema != CORPUS_ARCHIVE_SCHEMA_VERSION {
+        return Err(CorpusError::UnsupportedSchema {
+            found: arch.schema,
+        });
+    }
+    Ok(arch.seeds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_sorts_by_id_then_payload() {
+        let seeds = vec![
+            CaseSeed {
+                id: 2,
+                payload: vec![1],
+            },
+            CaseSeed {
+                id: 1,
+                payload: vec![2],
+            },
+            CaseSeed {
+                id: 1,
+                payload: vec![1],
+            },
+        ];
+        let bytes = export_corpus_json(&seeds).unwrap();
+        let loaded = import_corpus_json(&bytes).unwrap();
+        assert_eq!(loaded[0].id, 1);
+        assert_eq!(loaded[0].payload, vec![1]);
+        assert_eq!(loaded[1].id, 1);
+        assert_eq!(loaded[1].payload, vec![2]);
+        assert_eq!(loaded[2].id, 2);
+    }
+
+    #[test]
+    fn roundtrip_preserves_order_after_reimport() {
+        let seeds: Vec<CaseSeed> = (0..5)
+            .map(|i| CaseSeed {
+                id: i,
+                payload: vec![i as u8; 3],
+            })
+            .collect();
+        let bytes = export_corpus_json(&seeds).unwrap();
+        let again = import_corpus_json(&bytes).unwrap();
+        let bytes2 = export_corpus_json(&again).unwrap();
+        assert_eq!(bytes, bytes2);
+    }
+
+    #[test]
+    fn rejects_wrong_schema() {
+        let raw = r#"{"schema":999,"seeds":[]}"#;
+        let err = import_corpus_json(raw.as_bytes()).unwrap_err();
+        match err {
+            CorpusError::UnsupportedSchema { found } => assert_eq!(found, 999),
+            _ => panic!("expected UnsupportedSchema"),
+        }
+    }
+}

--- a/contracts/crashlab-core/src/lib.rs
+++ b/contracts/crashlab-core/src/lib.rs
@@ -37,6 +37,28 @@ pub use bundle_persist::{
 pub mod fixture_compat;
 pub use fixture_compat::{CompatReport, CompatWarning, check_bundle_fixtures, check_seed_fixtures};
 
+pub mod checkpoint;
+pub use checkpoint::{
+    load_run_checkpoint_json, save_run_checkpoint_json, CheckpointError, RunCheckpoint,
+    RUN_CHECKPOINT_SCHEMA_VERSION,
+};
+
+pub mod corpus;
+pub use corpus::{
+    corpus_archive_from_seeds, export_corpus_json, import_corpus_json, CorpusArchive, CorpusError,
+    CORPUS_ARCHIVE_SCHEMA_VERSION,
+};
+
+pub mod simulation;
+pub use simulation::{
+    run_simulation_with_timeout, timeout_crash_signature, RunMetadata, SimulationTimeoutConfig,
+};
+
+pub mod container_stress;
+pub use container_stress::{
+    generate_container_stress_grid, ContainerStressConfig, ContainerStressMutator,
+};
+
 /// Wrapper for the legacy bit-flipper mutation logic.
 pub struct DefaultMutator;
 

--- a/contracts/crashlab-core/src/simulation.rs
+++ b/contracts/crashlab-core/src/simulation.rs
@@ -1,0 +1,138 @@
+//! Bounded simulation runs with configurable wall-clock timeouts.
+//!
+//! When a user-supplied simulator exceeds the configured limit, the result is a
+//! [`CrashSignature`](crate::CrashSignature) with category `"timeout"` so runs
+//! can be triaged like other failure classes.
+
+use crate::{CaseSeed, CrashSignature, compute_signature_hash};
+use serde::{Deserialize, Serialize};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// Wall-clock limit for a single simulation invocation (milliseconds).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimulationTimeoutConfig {
+    pub timeout_ms: u64,
+}
+
+impl SimulationTimeoutConfig {
+    pub const fn new(timeout_ms: u64) -> Self {
+        Self { timeout_ms }
+    }
+}
+
+/// Metadata surfaced alongside a fuzzing run (e.g. for dashboards and CI logs).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunMetadata {
+    /// Active simulation timeout used for this run (milliseconds).
+    pub simulation_timeout_ms: u64,
+}
+
+impl RunMetadata {
+    pub fn from_timeout_config(cfg: &SimulationTimeoutConfig) -> Self {
+        Self {
+            simulation_timeout_ms: cfg.timeout_ms,
+        }
+    }
+}
+
+/// Builds the crash signature used when a simulation hits the timeout wall.
+pub fn timeout_crash_signature(seed: &CaseSeed) -> CrashSignature {
+    let category = "timeout";
+    let digest = seed
+        .payload
+        .iter()
+        .fold(seed.id, |acc, b| acc.wrapping_mul(1099511628211).wrapping_add(*b as u64))
+        ^ 0x7F4A_7C15_4E3F_4E3Fu64;
+    let signature_hash = compute_signature_hash(category, &seed.payload);
+    CrashSignature {
+        category: category.to_string(),
+        digest,
+        signature_hash,
+    }
+}
+
+/// Runs `simulator` on a worker thread; if it does not finish within `config`,
+/// returns [`timeout_crash_signature`] instead.
+///
+/// If the timeout fires, the worker thread is not forcibly stopped (host code
+/// may still run to completion in the background).
+pub fn run_simulation_with_timeout<F>(
+    seed: &CaseSeed,
+    config: &SimulationTimeoutConfig,
+    simulator: F,
+) -> CrashSignature
+where
+    F: FnOnce(&CaseSeed) -> CrashSignature + Send + 'static,
+{
+    if config.timeout_ms == 0 {
+        return timeout_crash_signature(seed);
+    }
+
+    let seed_clone = seed.clone();
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let sig = simulator(&seed_clone);
+        let _ = tx.send(sig);
+    });
+
+    match rx.recv_timeout(Duration::from_millis(config.timeout_ms)) {
+        Ok(sig) => sig,
+        Err(_) => timeout_crash_signature(seed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classify;
+    use std::thread;
+    use std::time::Duration as StdDuration;
+
+    #[test]
+    fn fast_simulator_returns_normally() {
+        let seed = CaseSeed {
+            id: 1,
+            payload: vec![0x50],
+        };
+        let cfg = SimulationTimeoutConfig::new(500);
+        let sig = run_simulation_with_timeout(&seed, &cfg, |s| classify(s));
+        assert_ne!(sig.category, "timeout");
+    }
+
+    #[test]
+    fn slow_simulator_marks_timeout() {
+        let seed = CaseSeed {
+            id: 2,
+            payload: vec![0x40, 0x41],
+        };
+        let cfg = SimulationTimeoutConfig::new(30);
+        let sig = run_simulation_with_timeout(&seed, &cfg, |_| {
+            thread::sleep(StdDuration::from_millis(200));
+            classify(&CaseSeed {
+                id: 2,
+                payload: vec![0x40, 0x41],
+            })
+        });
+        assert_eq!(sig.category, "timeout");
+    }
+
+    #[test]
+    fn zero_timeout_immediately_times_out() {
+        let seed = CaseSeed {
+            id: 3,
+            payload: vec![1],
+        };
+        let cfg = SimulationTimeoutConfig::new(0);
+        let sig = run_simulation_with_timeout(&seed, &cfg, |s| classify(s));
+        assert_eq!(sig.category, "timeout");
+    }
+
+    #[test]
+    fn run_metadata_surfaces_timeout() {
+        let cfg = SimulationTimeoutConfig::new(1234);
+        let meta = RunMetadata::from_timeout_config(&cfg);
+        assert_eq!(meta.simulation_timeout_ms, 1234);
+    }
+}


### PR DESCRIPTION
Closes #48
Closes #34
Closes #7
Closes #5

## What changed
- **Run checkpoints** (`RunCheckpoint`, JSON save/load): resume campaigns from `next_seed_index` without reprocessing completed seeds.
- **Corpus export**: `export_corpus_json` / `import_corpus_json` with deterministic `(id, payload)` sort; `export-corpus` CLI reads a JSON array or archive from stdin or a file and writes canonical archive JSON.
- **Simulation timeout**: `run_simulation_with_timeout`, `timeout_crash_signature`, and `RunMetadata.simulation_timeout_ms` for configurable wall-clock limits.
- **Container stress mutator**: `ContainerStressMutator` with `ContainerStressConfig` min/max bounds for vec/map sizes and sparse stride bytes.

## How to verify
```bash
cd contracts/crashlab-core
cargo test --all-targets
```

## Risk note
When a simulation times out, the worker thread is not forcibly stopped; the wall-clock deadline is enforced by returning a timeout signature only.

Made with [Cursor](https://cursor.com)