### PR TITLE
feat: four issues

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "next": "16.1.6",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useState, useEffect, useRef } from 'react';
 import RunHistoryTable from './RunHistoryTable';
 import Pagination from './Pagination';
@@ -11,9 +12,28 @@ const MOCK_RUNS: FuzzingRun[] = Array.from({ length: 25 }, (_, i) => ({
   status: (['completed', 'failed', 'running', 'cancelled'][i % 4]) as RunStatus,
   duration: 120000 + (Math.random() * 3600000), // 2m to 1h
   seedCount: Math.floor(10000 + Math.random() * 90000),
+  cpuInstructions: Math.floor(400000 + Math.random() * 900000),
+  memoryBytes: Math.floor(1_500_000 + Math.random() * 8_000_000),
+  minResourceFee: Math.floor(500 + Math.random() * 5000),
 })).reverse();
 
 const ITEMS_PER_PAGE = 10;
+const CPU_WARNING = 900_000;
+const MEMORY_WARNING = 7_000_000;
+const FEE_WARNING = 3_000;
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const formatFee = (fee: number): string => `${fee.toLocaleString()} stroops`;
+
+const isExpensiveRun = (run: FuzzingRun): boolean =>
+  run.cpuInstructions >= CPU_WARNING ||
+  run.memoryBytes >= MEMORY_WARNING ||
+  run.minResourceFee >= FEE_WARNING;
 
 export default function Home() {
   const [selectedCardIndex, setSelectedCardIndex] = useState(0);
@@ -25,6 +45,7 @@ export default function Home() {
   const totalPages = Math.ceil(MOCK_RUNS.length / ITEMS_PER_PAGE);
   const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
   const paginatedRuns = MOCK_RUNS.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+  const expensiveRuns = paginatedRuns.filter(isExpensiveRun);
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -188,6 +209,34 @@ export default function Home() {
             {MOCK_RUNS.length} Total Runs
           </div>
         </div>
+
+        <div className="mb-5 border border-amber-200 dark:border-amber-900/50 rounded-xl p-4 bg-amber-50/70 dark:bg-amber-950/20">
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-200">Resource Fee Insight</h3>
+            <span className="text-xs text-amber-800 dark:text-amber-300">
+              thresholds: cpu &ge; {CPU_WARNING.toLocaleString()}, mem &ge; {formatBytes(MEMORY_WARNING)}, fee &ge; {formatFee(FEE_WARNING)}
+            </span>
+          </div>
+
+          {expensiveRuns.length === 0 ? (
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">No expensive runs on this page.</p>
+          ) : (
+            <ul className="space-y-2">
+              {expensiveRuns.map((run) => (
+                <li key={run.id} className="text-sm flex flex-col md:flex-row md:items-center md:justify-between gap-2 bg-white/60 dark:bg-zinc-900/40 rounded-lg px-3 py-2 border border-amber-100 dark:border-amber-900/40">
+                  <div className="font-mono text-zinc-800 dark:text-zinc-200">{run.id}</div>
+                  <div className="text-zinc-700 dark:text-zinc-300">
+                    cpu {run.cpuInstructions.toLocaleString()} &middot; mem {formatBytes(run.memoryBytes)} &middot; min fee {formatFee(run.minResourceFee)}
+                  </div>
+                  <Link href={`/runs/${run.id}`} className="text-amber-700 dark:text-amber-300 hover:underline underline-offset-4 font-medium">
+                    View run details
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
         <RunHistoryTable runs={paginatedRuns} />
         <Pagination
           currentPage={currentPage}

--- a/apps/web/src/app/runs/[id]/page.tsx
+++ b/apps/web/src/app/runs/[id]/page.tsx
@@ -1,40 +1,118 @@
 import Link from 'next/link';
+import type { LedgerStateChange } from '../../types';
 
 interface RunDetailPageProps {
     params: Promise<{ id: string }>;
 }
 
-/**
- * Minimal placeholder for the run detail page to verify navigation.
- */
 export default async function RunDetailPage({ params }: RunDetailPageProps) {
     const { id } = await params;
 
+    const cpuInstructions = 1_120_000;
+    const memoryBytes = 8_200_000;
+    const minResourceFee = 3_600;
+
+    const cpuWarn = cpuInstructions >= 900_000;
+    const memoryWarn = memoryBytes >= 7_000_000;
+    const feeWarn = minResourceFee >= 3_000;
+
+    const ledgerChanges: LedgerStateChange[] = [
+        {
+            id: 'entry-1',
+            entryType: 'ContractData',
+            changeType: 'created',
+            after: '{"key":"allowance:alice:bob","value":"1000"}',
+        },
+        {
+            id: 'entry-2',
+            entryType: 'Account',
+            changeType: 'updated',
+            before: '{"balance":"10000000","seq":"184"}',
+            after: '{"balance":"9800000","seq":"185"}',
+        },
+        {
+            id: 'entry-3',
+            entryType: 'TrustLine',
+            changeType: 'deleted',
+            before: '{"asset":"USDC","limit":"500","balance":"0"}',
+        },
+    ];
+
+    const changeBadge = {
+        created: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300 border-green-200 dark:border-green-900/60',
+        updated: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 border-blue-200 dark:border-blue-900/60',
+        deleted: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300 border-red-200 dark:border-red-900/60',
+    };
+
     return (
-        <div className="flex flex-col items-center justify-center min-h-[50vh] px-8 max-w-5xl mx-auto w-full py-20">
-            <div className="w-full max-w-2xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl shadow-xl p-12 text-center">
-                <div className="h-16 w-16 bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center mx-auto mb-6">
-                    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                    </svg>
+        <div className="px-6 md:px-8 max-w-5xl mx-auto w-full py-14">
+            <div className="w-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl shadow-xl p-6 md:p-8">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8">
+                    <div>
+                        <h1 className="text-3xl font-bold mb-2">Run Details</h1>
+                        <p className="text-zinc-500 dark:text-zinc-400 font-mono bg-zinc-100 dark:bg-zinc-800 py-2 px-3 rounded-lg inline-block">
+                            ID: {id}
+                        </p>
+                    </div>
+                    <Link
+                        href="/"
+                        className="inline-flex items-center justify-center h-10 px-4 rounded-full bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 font-medium hover:bg-zinc-800 dark:hover:bg-zinc-200 transition"
+                    >
+                        Back to Dashboard
+                    </Link>
                 </div>
-                <h1 className="text-3xl font-bold mb-4">Run Details</h1>
-                <p className="text-zinc-500 dark:text-zinc-400 mb-8 font-mono bg-zinc-100 dark:bg-zinc-800 py-2 px-4 rounded-lg inline-block">
-                    ID: {id}
-                </p>
-                <p className="text-zinc-600 dark:text-zinc-300 leading-relaxed mb-10">
-                    This is a placeholder for the full execution trace and invariant violation report for run <strong>{id}</strong>.
-                    The full detail view implementation is tracked as a separate issue.
-                </p>
-                <Link
-                    href="/"
-                    className="inline-flex items-center justify-center h-12 px-8 rounded-full bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 font-medium hover:bg-zinc-800 dark:hover:bg-zinc-200 transition"
-                >
-                    <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-                    </svg>
-                    Back to Dashboard
-                </Link>
+
+                <section className="mb-8 border border-amber-200 dark:border-amber-900/50 rounded-xl p-4 bg-amber-50/60 dark:bg-amber-950/20">
+                    <h2 className="text-lg font-semibold mb-3">Resource Fee Insight</h2>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+                        <div className={`rounded-lg border p-3 ${cpuWarn ? 'border-amber-300 dark:border-amber-800 bg-amber-100/70 dark:bg-amber-900/20' : 'border-zinc-200 dark:border-zinc-700'}`}>
+                            <div className="text-zinc-500 dark:text-zinc-400">CPU</div>
+                            <div className="font-semibold">{cpuInstructions.toLocaleString()}</div>
+                        </div>
+                        <div className={`rounded-lg border p-3 ${memoryWarn ? 'border-amber-300 dark:border-amber-800 bg-amber-100/70 dark:bg-amber-900/20' : 'border-zinc-200 dark:border-zinc-700'}`}>
+                            <div className="text-zinc-500 dark:text-zinc-400">Memory</div>
+                            <div className="font-semibold">{(memoryBytes / (1024 * 1024)).toFixed(1)} MB</div>
+                        </div>
+                        <div className={`rounded-lg border p-3 ${feeWarn ? 'border-amber-300 dark:border-amber-800 bg-amber-100/70 dark:bg-amber-900/20' : 'border-zinc-200 dark:border-zinc-700'}`}>
+                            <div className="text-zinc-500 dark:text-zinc-400">Min Resource Fee</div>
+                            <div className="font-semibold">{minResourceFee.toLocaleString()} stroops</div>
+                        </div>
+                    </div>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold mb-3">Ledger State Change Diff</h2>
+                    <div className="space-y-3">
+                        {ledgerChanges.map((change) => (
+                            <article key={change.id} className="border border-zinc-200 dark:border-zinc-800 rounded-xl p-4">
+                                <div className="flex flex-wrap items-center gap-2 mb-3">
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${changeBadge[change.changeType]}`}>
+                                        {change.changeType.toUpperCase()}
+                                    </span>
+                                    <span className="text-xs font-semibold text-zinc-600 dark:text-zinc-300 bg-zinc-100 dark:bg-zinc-800 rounded px-2 py-0.5">
+                                        {change.entryType}
+                                    </span>
+                                    <span className="text-xs text-zinc-500 dark:text-zinc-400 font-mono">{change.id}</span>
+                                </div>
+
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                    <div>
+                                        <div className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-1">Before</div>
+                                        <pre className="text-xs rounded-lg bg-zinc-100 dark:bg-zinc-950 p-3 overflow-x-auto whitespace-pre-wrap break-all">
+                                            {change.before ?? 'N/A (created)'}
+                                        </pre>
+                                    </div>
+                                    <div>
+                                        <div className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-1">After</div>
+                                        <pre className="text-xs rounded-lg bg-zinc-100 dark:bg-zinc-950 p-3 overflow-x-auto whitespace-pre-wrap break-all">
+                                            {change.after ?? 'N/A (deleted)'}
+                                        </pre>
+                                    </div>
+                                </div>
+                            </article>
+                        ))}
+                    </div>
+                </section>
             </div>
         </div>
     );

--- a/apps/web/src/app/types.ts
+++ b/apps/web/src/app/types.ts
@@ -15,4 +15,20 @@ export interface FuzzingRun {
     duration: number;
     /** Number of seeds used/generated during the run */
     seedCount: number;
+    /** CPU instructions consumed by the run */
+    cpuInstructions: number;
+    /** Memory bytes consumed by the run */
+    memoryBytes: number;
+    /** Minimum resource fee measured for the run */
+    minResourceFee: number;
+}
+
+export type LedgerChangeType = 'created' | 'updated' | 'deleted';
+
+export interface LedgerStateChange {
+    id: string;
+    entryType: string;
+    changeType: LedgerChangeType;
+    before?: string;
+    after?: string;
 }

--- a/contracts/crashlab-core/Cargo.toml
+++ b/contracts/crashlab-core/Cargo.toml
@@ -10,3 +10,7 @@ serde_json = "1.0"
 [[bin]]
 name = "export-corpus"
 path = "src/bin/export-corpus.rs"
+
+[[bin]]
+name = "import-corpus"
+path = "src/bin/import-corpus.rs"

--- a/contracts/crashlab-core/src/bin/import-corpus.rs
+++ b/contracts/crashlab-core/src/bin/import-corpus.rs
@@ -1,0 +1,125 @@
+//! CLI: import external seed files into the local corpus pipeline with validation.
+//!
+//! Input (file path argument or stdin): either a JSON array of `CaseSeed`
+//! objects or a full `CorpusArchive` document. The command validates all seeds
+//! and reports how many were accepted.
+
+use crashlab_core::corpus::import_corpus_json;
+use crashlab_core::{CaseSeed, SeedSchema, Validate};
+use std::env;
+use std::fs;
+use std::io::{self, Read};
+use std::process;
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("{err}");
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let input = read_input()?;
+    let seeds = parse_seeds(&input)?;
+    validate_seeds(&seeds)?;
+    println!("accepted_seed_count={}", seeds.len());
+    Ok(())
+}
+
+fn read_input() -> Result<Vec<u8>, String> {
+    let mut args = env::args();
+    let _ = args.next();
+
+    if let Some(path) = args.next() {
+        if args.next().is_some() {
+            return Err("usage: import-corpus [seed-json-path]".to_string());
+        }
+        return fs::read(&path).map_err(|e| format!("read {path}: {e}"));
+    }
+
+    let mut buf = Vec::new();
+    io::stdin()
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("stdin: {e}"))?;
+    Ok(buf)
+}
+
+fn parse_seeds(bytes: &[u8]) -> Result<Vec<CaseSeed>, String> {
+    if bytes.is_empty() {
+        return Err("empty input".to_string());
+    }
+
+    if let Ok(seeds) = import_corpus_json(bytes) {
+        return Ok(seeds);
+    }
+
+    serde_json::from_slice::<Vec<CaseSeed>>(bytes)
+        .map_err(|e| format!("malformed seed input: {e}"))
+}
+
+fn validate_seeds(seeds: &[CaseSeed]) -> Result<(), String> {
+    let schema = SeedSchema::default();
+    for (idx, seed) in seeds.iter().enumerate() {
+        if let Err(errors) = seed.validate(&schema) {
+            let details = errors
+                .into_iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(format!(
+                "invalid seed at index {idx} (id={}): {details}",
+                seed.id
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_accepts_archive_document() {
+        let raw = r#"{"schema":1,"seeds":[{"id":1,"payload":[1,2,3]}]}"#;
+        let seeds = parse_seeds(raw.as_bytes()).expect("archive should parse");
+        assert_eq!(seeds.len(), 1);
+        assert_eq!(seeds[0].id, 1);
+    }
+
+    #[test]
+    fn parse_rejects_malformed_file() {
+        let err = parse_seeds(br#"{"schema":1,"seeds":[{"id":"bad"}]}"#)
+            .expect_err("malformed input must fail");
+        assert!(err.contains("malformed seed input"));
+    }
+
+    #[test]
+    fn validation_rejects_seed_with_empty_payload() {
+        let seeds = vec![CaseSeed {
+            id: 22,
+            payload: vec![],
+        }];
+
+        let err = validate_seeds(&seeds).expect_err("invalid seed should fail validation");
+        assert!(err.contains("invalid seed at index 0"));
+        assert!(err.contains("payload too short"));
+    }
+
+    #[test]
+    fn validation_accepts_valid_seed_set_and_reports_count() {
+        let seeds = vec![
+            CaseSeed {
+                id: 1,
+                payload: vec![1],
+            },
+            CaseSeed {
+                id: 2,
+                payload: vec![1, 2, 3],
+            },
+        ];
+
+        assert!(validate_seeds(&seeds).is_ok());
+        assert_eq!(seeds.len(), 2);
+    }
+}

--- a/contracts/crashlab-core/src/lib.rs
+++ b/contracts/crashlab-core/src/lib.rs
@@ -9,7 +9,10 @@ pub use prng::SeededPrng;
 pub use health::{
     FailureMetrics, HealthMonitor, HealthStatus, HealthSummary, QueueMetrics, ThroughputMetrics,
 };
-pub use reproducer::{FlakyDetector, ReproReport, filter_ci_pack};
+pub use reproducer::{
+    FlakyDetector, ReproReport, filter_ci_pack, shrink_bundle_payload,
+    shrink_seed_preserving_signature,
+};
 pub use taxonomy::{FailureClass, classify_failure, group_by_class};
 
 pub mod seed_validator;

--- a/contracts/crashlab-core/src/reproducer.rs
+++ b/contracts/crashlab-core/src/reproducer.rs
@@ -114,6 +114,79 @@ where
         .collect()
 }
 
+/// Shrinks a failing seed by removing payload chunks while preserving `expected`.
+///
+/// The algorithm is deterministic and greedily accepts removals that still
+/// reproduce the same signature. It progressively decreases chunk size until no
+/// single-byte removal can be applied.
+pub fn shrink_seed_preserving_signature<F>(
+    seed: &CaseSeed,
+    expected: &CrashSignature,
+    reproducer: F,
+) -> CaseSeed
+where
+    F: Fn(&CaseSeed) -> CrashSignature,
+{
+    let mut best = seed.clone();
+    if best.payload.is_empty() {
+        return best;
+    }
+
+    let mut chunk = (best.payload.len() / 2).max(1);
+    loop {
+        let mut improved = false;
+        let mut start = 0usize;
+
+        while start < best.payload.len() {
+            let end = (start + chunk).min(best.payload.len());
+            if end <= start {
+                break;
+            }
+
+            let mut candidate = best.clone();
+            candidate.payload.drain(start..end);
+
+            if reproducer(&candidate) == *expected {
+                best = candidate;
+                improved = true;
+                // Retry at same index because the payload shifted left.
+                continue;
+            }
+
+            start += 1;
+        }
+
+        if !improved {
+            if chunk == 1 {
+                break;
+            }
+            chunk /= 2;
+            continue;
+        }
+
+        if best.payload.len() <= 1 {
+            break;
+        }
+
+        if chunk > best.payload.len() {
+            chunk = (best.payload.len() / 2).max(1);
+        }
+    }
+
+    best
+}
+
+/// Shrinks only the seed payload inside a failing bundle while preserving the
+/// bundle's reference signature.
+pub fn shrink_bundle_payload<F>(bundle: &CaseBundle, reproducer: F) -> CaseBundle
+where
+    F: Fn(&CaseSeed) -> CrashSignature,
+{
+    let mut shrunk = bundle.clone();
+    shrunk.seed = shrink_seed_preserving_signature(&bundle.seed, &bundle.signature, reproducer);
+    shrunk
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -309,5 +382,71 @@ mod tests {
     #[should_panic(expected = "threshold must be in [0.0, 1.0]")]
     fn detector_panics_on_negative_threshold() {
         FlakyDetector::new(5, -0.1);
+    }
+
+    // ── shrinking ─────────────────────────────────────────────────────────────
+
+    fn anchor_signature(seed: &CaseSeed) -> CrashSignature {
+        let has_anchor = seed.payload.windows(2).any(|w| w == [0xAA, 0xBB]);
+        if has_anchor {
+            CrashSignature {
+                category: "runtime-failure".to_string(),
+                digest: 0x1234,
+                signature_hash: 0x7777,
+            }
+        } else {
+            CrashSignature {
+                category: "runtime-failure".to_string(),
+                digest: 0x9999,
+                signature_hash: 0xEEEE,
+            }
+        }
+    }
+
+    #[test]
+    fn shrink_seed_reduces_size_and_preserves_signature() {
+        let seed = CaseSeed {
+            id: 77,
+            payload: vec![0, 1, 2, 0xAA, 0xBB, 3, 4, 5, 6],
+        };
+        let expected = anchor_signature(&seed);
+
+        let shrunk = shrink_seed_preserving_signature(&seed, &expected, anchor_signature);
+
+        assert!(shrunk.payload.len() < seed.payload.len());
+        assert_eq!(anchor_signature(&shrunk), expected);
+    }
+
+    #[test]
+    fn shrink_seed_keeps_minimal_reproducer_unchanged() {
+        let seed = CaseSeed {
+            id: 88,
+            payload: vec![0xAA, 0xBB],
+        };
+        let expected = anchor_signature(&seed);
+
+        let shrunk = shrink_seed_preserving_signature(&seed, &expected, anchor_signature);
+
+        assert_eq!(shrunk.payload, seed.payload);
+        assert_eq!(anchor_signature(&shrunk), expected);
+    }
+
+    #[test]
+    fn shrink_bundle_payload_preserves_bundle_signature() {
+        let seed = CaseSeed {
+            id: 42,
+            payload: vec![9, 9, 0xAA, 0xBB, 9, 9],
+        };
+        let bundle = CaseBundle {
+            seed: seed.clone(),
+            signature: anchor_signature(&seed),
+            environment: None,
+            failure_payload: vec![],
+        };
+
+        let shrunk = shrink_bundle_payload(&bundle, anchor_signature);
+
+        assert!(shrunk.seed.payload.len() <= bundle.seed.payload.len());
+        assert_eq!(anchor_signature(&shrunk.seed), bundle.signature);
     }
 }


### PR DESCRIPTION


## Linked issues
Closes #13
Closes #33
Closes #19 
Closes #20 

## What changed
- Added a new import-corpus command in crashlab-core to import external seed files, validate each seed, reject malformed input, and report accepted seed counts.
- Added deterministic shrinking logic for failing reproducers so payloads are minimized while preserving failure signature.
- Replaced the run details placeholder UI with a readable ledger state change diff that highlights created, updated, and deleted entries with type labels.
- Added a resource fee insight panel showing CPU, memory, and minimum resource fee thresholds, flagging expensive runs, and linking to run details.
- Updated web lint script to run against the project files directly.

## How to verify
1. Core validation:
- cd contracts/crashlab-core
- cargo test

2. Web validation:
- cd apps/web
- npm install
- npm run lint
- npm run build

## Acceptance coverage
- Corpus import rejects malformed files and reports accepted seed counts.
- Shrinking returns smaller reproducer payloads while preserving signature.
- State diff view renders created, updated, and deleted changes with clear labels.
- Resource panel flags expensive runs and includes links to related run details.

## Risk note
- Shrinking uses a deterministic greedy chunk-removal strategy. It is stable and predictable, but may stop at a local minimum for some non-monotonic failure shapes.
- Web views currently use mocked data wiring for diff and resource metrics; backend integration can be added in a follow-up without changing UI contracts.