### PR TITLE
[#18] Build crash detail drawer UI

### DIFF
--- a/apps/web/src/app/CrashDetailDrawer.tsx
+++ b/apps/web/src/app/CrashDetailDrawer.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import Link from 'next/link';
+import { FuzzingRun } from './types';
+
+interface CrashDetailDrawerProps {
+    run: FuzzingRun;
+    onClose: () => void;
+}
+
+export default function CrashDetailDrawer({ run, onClose }: CrashDetailDrawerProps) {
+    return (
+        <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-labelledby="crash-detail-title">
+            <button
+                type="button"
+                className="absolute inset-0 bg-black/40 dark:bg-black/60"
+                onClick={onClose}
+                aria-label="Close crash detail drawer"
+            />
+            <aside className="absolute right-0 top-0 h-full w-full max-w-xl bg-white dark:bg-zinc-950 shadow-2xl border-l border-zinc-200 dark:border-zinc-800 p-6 overflow-y-auto">
+                <div className="flex items-start justify-between gap-4 mb-6">
+                    <div>
+                        <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-2">Crash Details</p>
+                        <h2 id="crash-detail-title" className="text-2xl font-bold">Run {run.id}</h2>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                        aria-label="Close drawer"
+                    >
+                        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                {run.crashDetail ? (
+                    <div className="space-y-5">
+                        <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-4">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-1">Failure Category</p>
+                            <p className="font-medium">{run.crashDetail.failureCategory}</p>
+                        </div>
+
+                        <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-4">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-1">Signature</p>
+                            <p className="font-mono text-sm break-all">{run.crashDetail.signature}</p>
+                        </div>
+
+                        <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-4">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-1">Payload</p>
+                            <pre className="font-mono text-xs whitespace-pre-wrap break-words text-zinc-700 dark:text-zinc-300">
+                                {run.crashDetail.payload}
+                            </pre>
+                        </div>
+
+                        <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-4">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400 mb-1">Replay Action</p>
+                            <p className="font-mono text-xs whitespace-pre-wrap break-words">{run.crashDetail.replayAction}</p>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700 p-4 text-sm text-zinc-600 dark:text-zinc-300">
+                        No crash details are available for this run.
+                    </div>
+                )}
+
+                <div className="mt-8 flex items-center justify-end gap-3">
+                    <Link
+                        href={`/runs/${run.id}`}
+                        className="px-4 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-50 dark:hover:bg-zinc-900 transition"
+                    >
+                        Open Run Page
+                    </Link>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition"
+                    >
+                        Close
+                    </button>
+                </div>
+            </aside>
+        </div>
+    );
+}

--- a/apps/web/src/app/RunHistoryTable.tsx
+++ b/apps/web/src/app/RunHistoryTable.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import Link from 'next/link';
 import { FuzzingRun, RunStatus } from './types';
 
 interface RunHistoryTableProps {
     /** Array of fuzzing runs to display */
     runs: FuzzingRun[];
+    /** Called when a row is selected */
+    onSelectRun: (runId: string) => void;
 }
 
 /**
@@ -46,7 +47,7 @@ const StatusBadge = ({ status }: { status: RunStatus }) => {
 /**
  * Table component for displaying a list of fuzzing runs.
  */
-export default function RunHistoryTable({ runs }: RunHistoryTableProps) {
+export default function RunHistoryTable({ runs, onSelectRun }: RunHistoryTableProps) {
     if (runs.length === 0) {
         return (
             <div className="flex flex-col items-center justify-center p-12 border border-dashed rounded-xl bg-zinc-50 dark:bg-zinc-900/20 border-zinc-200 dark:border-zinc-800">
@@ -73,14 +74,16 @@ export default function RunHistoryTable({ runs }: RunHistoryTableProps) {
                             <tr
                                 key={run.id}
                                 className="group hover:bg-zinc-50 dark:hover:bg-zinc-900/30 transition-colors cursor-pointer"
+                                onClick={() => onSelectRun(run.id)}
                             >
                                 <td className="px-6 py-4">
-                                    <Link
-                                        href={`/runs/${run.id}`}
+                                    <button
+                                        type="button"
+                                        onClick={() => onSelectRun(run.id)}
                                         className="text-sm font-mono text-blue-600 dark:text-blue-400 hover:underline decoration-blue-500/30 underline-offset-4"
                                     >
                                         {run.id}
-                                    </Link>
+                                    </button>
                                 </td>
                                 <td className="px-6 py-4">
                                     <StatusBadge status={run.status} />

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,9 +2,11 @@
 
 import Link from 'next/link';
 import { useState, useEffect, useRef } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import RunHistoryTable from './RunHistoryTable';
 import Pagination from './Pagination';
 import { FuzzingRun, RunStatus } from './types';
+import CrashDetailDrawer from './CrashDetailDrawer';
 
 // Mock data for demonstration
 const MOCK_RUNS: FuzzingRun[] = Array.from({ length: 25 }, (_, i) => ({
@@ -15,6 +17,22 @@ const MOCK_RUNS: FuzzingRun[] = Array.from({ length: 25 }, (_, i) => ({
   cpuInstructions: Math.floor(400000 + Math.random() * 900000),
   memoryBytes: Math.floor(1_500_000 + Math.random() * 8_000_000),
   minResourceFee: Math.floor(500 + Math.random() * 5000),
+  crashDetail: i % 4 === 1
+    ? {
+      failureCategory: i % 8 === 1 ? 'Panic' : 'InvariantViolation',
+      signature: `sig:${1000 + i}:contract::transfer:assert_balance_nonnegative`,
+      payload: JSON.stringify({
+        contract: 'token',
+        method: 'transfer',
+        args: {
+          from: 'GABCD...1234',
+          to: 'GXYZ...7890',
+          amount: 999999999,
+        },
+      }, null, 2),
+      replayAction: `cargo run --bin crash-replay -- --run-id run-${1000 + i}`,
+    }
+    : null,
 })).reverse();
 
 const ITEMS_PER_PAGE = 10;
@@ -36,16 +54,21 @@ const isExpensiveRun = (run: FuzzingRun): boolean =>
   run.minResourceFee >= FEE_WARNING;
 
 export default function Home() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [selectedCardIndex, setSelectedCardIndex] = useState(0);
   const [showDetailView, setShowDetailView] = useState(false);
   const [showHelp, setShowHelp] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
   const cardsContainerRef = useRef<HTMLDivElement>(null);
+  const selectedRunId = searchParams.get('run');
 
   const totalPages = Math.ceil(MOCK_RUNS.length / ITEMS_PER_PAGE);
   const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
   const paginatedRuns = MOCK_RUNS.slice(startIndex, startIndex + ITEMS_PER_PAGE);
   const expensiveRuns = paginatedRuns.filter(isExpensiveRun);
+  const selectedRun = selectedRunId ? MOCK_RUNS.find((run) => run.id === selectedRunId) : null;
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -118,6 +141,22 @@ export default function Home() {
     setSelectedCardIndex(index);
     setShowDetailView(true);
   };
+
+  const updateSelectedRunInUrl = (runId: string | null) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (runId) {
+      params.set('run', runId);
+    } else {
+      params.delete('run');
+    }
+
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  };
+
+  const handleOpenRunDrawer = (runId: string) => updateSelectedRunInUrl(runId);
+  const handleCloseRunDrawer = () => updateSelectedRunInUrl(null);
 
   return (
     <div className="flex flex-col items-center justify-center py-20 px-8 max-w-5xl mx-auto w-full">
@@ -209,7 +248,6 @@ export default function Home() {
             {MOCK_RUNS.length} Total Runs
           </div>
         </div>
-
         <div className="mb-5 border border-amber-200 dark:border-amber-900/50 rounded-xl p-4 bg-amber-50/70 dark:bg-amber-950/20">
           <div className="flex items-center justify-between gap-3 mb-3">
             <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-200">Resource Fee Insight</h3>
@@ -236,8 +274,7 @@ export default function Home() {
             </ul>
           )}
         </div>
-
-        <RunHistoryTable runs={paginatedRuns} />
+        <RunHistoryTable runs={paginatedRuns} onSelectRun={handleOpenRunDrawer} />
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages}
@@ -299,6 +336,10 @@ export default function Home() {
             </div>
           </div>
         </div>
+      )}
+
+      {selectedRun && (
+        <CrashDetailDrawer run={selectedRun} onClose={handleCloseRunDrawer} />
       )}
 
       <div className="mt-16 text-center border-t border-black/[.08] dark:border-white/[.145] pt-12 w-full">

--- a/apps/web/src/app/types.ts
+++ b/apps/web/src/app/types.ts
@@ -4,6 +4,20 @@
 export type RunStatus = 'running' | 'completed' | 'failed' | 'cancelled';
 
 /**
+ * Crash details captured when a run fails.
+ */
+export interface CrashDetail {
+    /** High-level category used to group failures */
+    failureCategory: string;
+    /** Stable signature for de-duplicating failures */
+    signature: string;
+    /** Payload associated with the failing input */
+    payload: string;
+    /** Command or action used to replay locally */
+    replayAction: string;
+}
+
+/**
  * Interface representing a single fuzzing run.
  */
 export interface FuzzingRun {
@@ -15,6 +29,8 @@ export interface FuzzingRun {
     duration: number;
     /** Number of seeds used/generated during the run */
     seedCount: number;
+    /** Crash detail payload when the run has failed */
+    crashDetail: CrashDetail | null;
     /** CPU instructions consumed by the run */
     cpuInstructions: number;
     /** Memory bytes consumed by the run */


### PR DESCRIPTION
Closes #18

## What changed
- Added a run crash-detail drawer UI that opens from the run history table.
- Added failure category, signature, payload, and replay action sections in the drawer.
- Persisted selected run drawer state in the URL query (un) so refresh/back-forward preserves state.

## How to verify
- cd apps/web
- npm install
- npm run lint
- npm run build
- Run the app and click a run row in Recent Fuzzing Runs; confirm the side drawer opens with crash details and URL includes ?run=<id>.