### PR TITLE
[#46] Add run cancellation command

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useEffect, useRef } from 'react';
+import { Suspense, useState, useEffect, useRef } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import RunHistoryTable from './RunHistoryTable';
 import Pagination from './Pagination';
@@ -53,7 +53,7 @@ const isExpensiveRun = (run: FuzzingRun): boolean =>
   run.memoryBytes >= MEMORY_WARNING ||
   run.minResourceFee >= FEE_WARNING;
 
-export default function Home() {
+function HomeContent() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -367,5 +367,13 @@ export default function Home() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function Home() {
+  return (
+    <Suspense fallback={<div className="py-20 text-center text-zinc-500">Loading dashboard…</div>}>
+      <HomeContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- Add a maintainers' `crashlab run cancel <id>` command that writes a cancellation marker for active runs.
- Introduce `run_control` primitives (`CancelSignal`, `RunTerminalState`, `drive_run`) so workers can stop gracefully and report a partial summary in a terminal cancelled state.
- Export run cancellation APIs from `crashlab_core` for integration by runtime components.
- Wrap the dashboard page in a Suspense boundary to satisfy Next.js prerender requirements in CI.

Closes #46

## Test plan
- `cargo test --all-targets` in `contracts/crashlab-core`