### PR TITLE
Add configurable artifact retention policy for run artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ cargo test
 
 Persist a [`RunCheckpoint`](contracts/crashlab-core/src/checkpoint.rs) (JSON) with `next_seed_index` and reload it after an interruption. Use `RunCheckpoint::remaining(&seeds)` to iterate only pending seeds, and `advance_one` / `advance_by` after each completed item so resumed runs skip finished work.
 
+### Artifact retention policy
+
+Apply configurable retention windows for old run artifacts with [`RetentionPolicy`](contracts/crashlab-core/src/retention.rs). Configure `max_failure_bundles` to keep the most recent failures (sorted by descending seed ID) and `max_checkpoints_per_campaign` to retain the most advanced checkpoints per campaign. Use `RetentionPolicy::retain_failure_bundles` and `RetentionPolicy::retain_checkpoints` to determine which artifacts to prune.
+
 ### Corpus export (portable seed archive)
 
 Export a deterministic, sorted corpus JSON (schema `CORPUS_ARCHIVE_SCHEMA_VERSION`) via `export_corpus_json` / `import_corpus_json`, or the CLI:

--- a/contracts/crashlab-core/src/lib.rs
+++ b/contracts/crashlab-core/src/lib.rs
@@ -55,6 +55,9 @@ pub use corpus::{
     CORPUS_ARCHIVE_SCHEMA_VERSION,
 };
 
+pub mod retention;
+pub use retention::RetentionPolicy;
+
 pub mod scenario_export;
 pub use scenario_export::{FailureScenario, export_scenario_json};
 

--- a/contracts/crashlab-core/src/retention.rs
+++ b/contracts/crashlab-core/src/retention.rs
@@ -1,0 +1,149 @@
+//! Configurable retention policies for run artifacts.
+//!
+//! Apply retention windows to prune old non-critical data while preserving
+//! the latest failures and essential checkpoints.
+
+use crate::{CaseBundleDocument, RunCheckpoint};
+use std::collections::HashMap;
+
+/// Configuration for artifact retention policies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionPolicy {
+    /// Maximum number of failure bundles to retain (keep the most recent by seed ID).
+    pub max_failure_bundles: usize,
+    /// Maximum number of checkpoints to retain per campaign (keep the most advanced).
+    pub max_checkpoints_per_campaign: usize,
+}
+
+impl Default for RetentionPolicy {
+    fn default() -> Self {
+        Self {
+            max_failure_bundles: 100,
+            max_checkpoints_per_campaign: 5,
+        }
+    }
+}
+
+impl RetentionPolicy {
+    /// Returns a vector of booleans indicating which bundles to retain (true = keep).
+    ///
+    /// Retains the `max_failure_bundles` most recent failures, sorted by descending seed ID.
+    pub fn retain_failure_bundles(&self, bundles: &[CaseBundleDocument]) -> Vec<bool> {
+        let mut indices: Vec<usize> = (0..bundles.len()).collect();
+        indices.sort_by_key(|&i| std::cmp::Reverse(bundles[i].seed.id));
+        let mut keep = vec![false; bundles.len()];
+        for &i in indices.iter().take(self.max_failure_bundles) {
+            keep[i] = true;
+        }
+        keep
+    }
+
+    /// Returns a vector of booleans indicating which checkpoints to retain (true = keep).
+    ///
+    /// For each campaign, retains up to `max_checkpoints_per_campaign` checkpoints
+    /// with the highest `next_seed_index` (most advanced).
+    pub fn retain_checkpoints(&self, checkpoints: &[RunCheckpoint]) -> Vec<bool> {
+        let mut campaign_checkpoints: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+        for (i, ck) in checkpoints.iter().enumerate() {
+            campaign_checkpoints
+                .entry(ck.campaign_id.clone())
+                .or_default()
+                .push((i, ck.next_seed_index));
+        }
+        let mut keep = vec![false; checkpoints.len()];
+        for (_campaign, mut cks) in campaign_checkpoints {
+            // Sort by next_seed_index descending
+            cks.sort_by_key(|&(_, idx)| std::cmp::Reverse(idx));
+            // Keep the top max_checkpoints_per_campaign
+            for &(i, _) in cks.iter().take(self.max_checkpoints_per_campaign) {
+                keep[i] = true;
+            }
+        }
+        keep
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CaseBundleDocument, CaseSeed, CrashSignature, FailureClass, RunCheckpoint};
+
+    #[test]
+    fn test_retain_failure_bundles() {
+        let policy = RetentionPolicy {
+            max_failure_bundles: 2,
+            max_checkpoints_per_campaign: 1,
+        };
+
+        let bundles = vec![
+            CaseBundleDocument {
+                schema: 1,
+                seed: CaseSeed { id: 1, payload: vec![1] },
+                signature: CrashSignature {
+                    category: FailureClass::Auth,
+                    digest: 1,
+                    signature_hash: 1,
+                },
+                environment: None,
+                failure_payload: vec![],
+            },
+            CaseBundleDocument {
+                schema: 1,
+                seed: CaseSeed { id: 3, payload: vec![3] },
+                signature: CrashSignature {
+                    category: FailureClass::Budget,
+                    digest: 3,
+                    signature_hash: 3,
+                },
+                environment: None,
+                failure_payload: vec![],
+            },
+            CaseBundleDocument {
+                schema: 1,
+                seed: CaseSeed { id: 2, payload: vec![2] },
+                signature: CrashSignature {
+                    category: FailureClass::State,
+                    digest: 2,
+                    signature_hash: 2,
+                },
+                environment: None,
+                failure_payload: vec![],
+            },
+        ];
+
+        let keep = policy.retain_failure_bundles(&bundles);
+        assert_eq!(keep, vec![false, true, true]); // keep id 3 and 2 (highest), not 1
+    }
+
+    #[test]
+    fn test_retain_checkpoints() {
+        let policy = RetentionPolicy {
+            max_failure_bundles: 1,
+            max_checkpoints_per_campaign: 1,
+        };
+
+        let checkpoints = vec![
+            RunCheckpoint {
+                schema: 1,
+                campaign_id: "camp1".to_string(),
+                next_seed_index: 10,
+                total_seeds: 100,
+            },
+            RunCheckpoint {
+                schema: 1,
+                campaign_id: "camp1".to_string(),
+                next_seed_index: 20,
+                total_seeds: 100,
+            },
+            RunCheckpoint {
+                schema: 1,
+                campaign_id: "camp2".to_string(),
+                next_seed_index: 5,
+                total_seeds: 50,
+            },
+        ];
+
+        let keep = policy.retain_checkpoints(&checkpoints);
+        assert_eq!(keep, vec![false, true, true]); // keep the highest for camp1 (index 1), and for camp2 (index 2)
+    }
+}


### PR DESCRIPTION
#closes #51 

I have successfully implemented the retention policy for run artifacts as required by issue . Here's what was added:

### Changes Made

1. **New Module**: Created retention.rs with:
   - `RetentionPolicy` struct with configurable `max_failure_bundles` and `max_checkpoints_per_campaign`
   - `retain_failure_bundles()` method to keep the most recent failures (by seed ID)
   - `retain_checkpoints()` method to keep the most advanced checkpoints per campaign

2. **Library Exports**: Updated lib.rs to export `RetentionPolicy`

3. **Documentation**: Added retention policy section to README.md explaining usage

4. **Tests**: Added unit tests in retention.rs to validate the retention logic

### Step-by-Step Testing Process

To verify that the assignment is completed successfully, follow these steps:

1. **Navigate to the core crate directory**:
   ```bash
   cd contracts/crashlab-core
   ```

2. **Run the tests to ensure the retention logic works**:
   ```bash
   cargo test retention
   ```
   - Expected: All tests pass (2 tests: `test_retain_failure_bundles` and `test_retain_checkpoints`)
   - This validates that the policy correctly keeps latest failures and prunes old checkpoints

3. **Build the crate to ensure no compilation errors**:
   ```bash
   cargo build
   ```
   - Expected: Successful build with no errors
   - Confirms the new module integrates properly with the existing codebase

4. **Verify the new exports are available**:
   ```bash
   cargo doc --open
   ```
   - Or check that `RetentionPolicy` appears in the generated documentation
   - Confirms the public API is properly exposed

5. **Test the acceptance criteria**:
   - The policy keeps latest failures (tested by sorting bundles by descending seed ID)
   - Prunes old non-critical data (checkpoints beyond the limit per campaign)
   - Configurable via `RetentionPolicy` fields

6. **Check documentation updates**:
   - Open README.md and verify the new "Artifact retention policy" section exists
   - Confirms users can understand how to use the feature

If all steps complete successfully without errors, the assignment is fully implemented and meets the acceptance criteria. The retention policy allows keeping the latest failures while pruning old checkpoints and other non-critical artifacts.

Made changes.