### PR TITLE
feat: add security policy and coordinated disclosure path (#29)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest commit on `main` is actively maintained. There are no versioned releases at this time.
+
+| Branch | Supported |
+|--------|-----------|
+| `main` | ✅ Yes    |
+| older  | ❌ No     |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+To report a vulnerability, please use one of the following private channels:
+
+- **GitHub private vulnerability reporting**: Use the [Security tab → "Report a vulnerability"](../../security/advisories/new) button in this repository. This is the preferred path.
+- **Email**: If GitHub private reporting is unavailable, email the maintainers directly. Contact details are listed in [`FUNDING.json`](../FUNDING.json) or the repository profile.
+
+### What to include
+
+A useful report includes:
+
+- A clear description of the vulnerability and its potential impact
+- Steps to reproduce or a minimal proof-of-concept
+- Affected component(s) (e.g., `crashlab-core`, `apps/web`, CI scripts)
+- Any suggested mitigations or patches, if available
+
+### Response expectations
+
+| Step | Target timeline |
+|------|----------------|
+| Acknowledgement of report | 48 hours |
+| Initial triage and severity assessment | 5 business days |
+| Fix or mitigation plan communicated to reporter | 14 days |
+| Public disclosure (coordinated with reporter) | 90 days from report, or sooner if fix is ready |
+
+We follow a **coordinated disclosure** model. We ask reporters to keep details private until a fix is available or the 90-day window closes, whichever comes first. We will credit reporters in the advisory unless they prefer to remain anonymous.
+
+## Scope
+
+This policy covers:
+
+- `contracts/crashlab-core` — Rust fuzzing and reproducibility crate
+- `apps/web` — Next.js frontend dashboard
+- CI/CD configuration under `.github/workflows`
+- Scripts under `scripts/`
+
+Out of scope: third-party dependencies (report those upstream), and issues that require physical access to infrastructure.
+
+## Known Gaps and Accepted Risks
+
+See the [Operational Security Assumptions](../MAINTAINER_WAVE_PLAYBOOK.md#operational-security-assumptions) section of the Maintainer Wave Playbook for a documented list of known gaps and accepted residual risks.

--- a/MAINTAINER_WAVE_PLAYBOOK.md
+++ b/MAINTAINER_WAVE_PLAYBOOK.md
@@ -66,6 +66,10 @@ Review inside 24 hours to prevent unnecessary automated appeals. Review in this 
 4. Test coverage
 5. Clarity and maintainability
 
+## Security Policy
+
+The project's coordinated vulnerability disclosure process and response expectations are defined in [`.github/SECURITY.md`](.github/SECURITY.md). Maintainers are responsible for triaging incoming reports within the timelines specified there.
+
 ## Operational Security Assumptions
 
 ### Deployment Trust Assumptions

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Most contract failures happen in edge cases that are not covered by manual tests
 - convert failures into deterministic regression tests
 - review risk and state-impact signals in a frontend dashboard
 
+## Security
+
+To report a vulnerability, see our [Security Policy](.github/SECURITY.md). Do not open a public issue for security concerns.
+
 ## Repository structure
 
 - `apps/web`: Next.js frontend dashboard for runs, failures, and replay output


### PR DESCRIPTION
- Add .github/SECURITY.md with supported versions, private reporting channels, response timeline, scope, and known gaps reference
- Link security policy from README.md
- Add Security Policy section in MAINTAINER_WAVE_PLAYBOOK.md

Closes #29 

## Summary

Describe what changed and why.

## Linked Issue

Closes #

## Validation

- [ ] frontend checks pass (`npm run lint`, `npm run build`)
- [ ] core checks pass (`cargo test`)
- [ ] behavior is reproducible with included steps

## Notes for Maintainers

Any migration, risk, or rollout notes.
