### PR TITLE
chore: Add Run filtering by severity

### DIFF
--- a/apps/web/src/app/add-run-filtering-by-severity.test.ts
+++ b/apps/web/src/app/add-run-filtering-by-severity.test.ts
@@ -1,0 +1,117 @@
+import {
+  filterRunsBySeverity,
+  isValidSeverityFilter,
+  matchesSeverityFilter,
+  SEVERITY_OPTIONS,
+} from './add-run-filtering-by-severity';
+import { FuzzingRun, RunSeverity } from './types';
+
+function makeRun(overrides: Partial<FuzzingRun> = {}): FuzzingRun {
+  return {
+    id: 'run-001',
+    status: 'completed',
+    area: 'auth',
+    severity: 'low',
+    duration: 1000,
+    seedCount: 10,
+    crashDetail: null,
+    cpuInstructions: 100,
+    memoryBytes: 1024,
+    minResourceFee: 0,
+    ...overrides,
+  };
+}
+
+describe('SEVERITY_OPTIONS', () => {
+  it('contains all four severity levels plus "all"', () => {
+    expect(SEVERITY_OPTIONS).toEqual(['all', 'low', 'medium', 'high', 'critical']);
+  });
+});
+
+describe('isValidSeverityFilter', () => {
+  it('returns true for "all"', () => {
+    expect(isValidSeverityFilter('all')).toBe(true);
+  });
+
+  it.each(['low', 'medium', 'high', 'critical'] as RunSeverity[])(
+    'returns true for valid severity "%s"',
+    (sev) => {
+      expect(isValidSeverityFilter(sev)).toBe(true);
+    },
+  );
+
+  it('returns false for an unknown string', () => {
+    expect(isValidSeverityFilter('extreme')).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isValidSeverityFilter('')).toBe(false);
+  });
+});
+
+describe('matchesSeverityFilter', () => {
+  it('always returns true when filter is "all"', () => {
+    const severities: RunSeverity[] = ['low', 'medium', 'high', 'critical'];
+    severities.forEach((sev) => {
+      expect(matchesSeverityFilter(makeRun({ severity: sev }), 'all')).toBe(true);
+    });
+  });
+
+  it('returns true when run severity matches the filter', () => {
+    expect(matchesSeverityFilter(makeRun({ severity: 'high' }), 'high')).toBe(true);
+  });
+
+  it('returns false when run severity does not match the filter', () => {
+    expect(matchesSeverityFilter(makeRun({ severity: 'low' }), 'critical')).toBe(false);
+  });
+
+  it('returns false for a critical run when filter is "medium"', () => {
+    expect(matchesSeverityFilter(makeRun({ severity: 'critical' }), 'medium')).toBe(false);
+  });
+});
+
+describe('filterRunsBySeverity', () => {
+  const runs: FuzzingRun[] = [
+    makeRun({ id: 'r1', severity: 'low' }),
+    makeRun({ id: 'r2', severity: 'medium' }),
+    makeRun({ id: 'r3', severity: 'high' }),
+    makeRun({ id: 'r4', severity: 'critical' }),
+    makeRun({ id: 'r5', severity: 'critical' }),
+  ];
+
+  it('returns all runs when filter is "all"', () => {
+    expect(filterRunsBySeverity(runs, 'all')).toHaveLength(5);
+  });
+
+  it('returns only runs matching the given severity', () => {
+    const result = filterRunsBySeverity(runs, 'critical');
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.severity === 'critical')).toBe(true);
+  });
+
+  it('returns an empty array when no runs match the filter', () => {
+    const result = filterRunsBySeverity(runs, 'low');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('r1');
+  });
+
+  it('returns an empty array when input is empty', () => {
+    expect(filterRunsBySeverity([], 'high')).toEqual([]);
+  });
+
+  // Edge case: all runs share the same severity
+  it('returns all runs when every run matches the filter', () => {
+    const allHigh = [
+      makeRun({ id: 'a', severity: 'high' }),
+      makeRun({ id: 'b', severity: 'high' }),
+    ];
+    expect(filterRunsBySeverity(allHigh, 'high')).toHaveLength(2);
+  });
+
+  it('does not mutate the original array', () => {
+    const original = [makeRun({ severity: 'low' }), makeRun({ severity: 'high' })];
+    const copy = [...original];
+    filterRunsBySeverity(original, 'low');
+    expect(original).toEqual(copy);
+  });
+});

--- a/apps/web/src/app/add-run-filtering-by-severity.tsx
+++ b/apps/web/src/app/add-run-filtering-by-severity.tsx
@@ -1,33 +1,62 @@
 'use client';
 
 import React from 'react';
-import { RunSeverity } from './types';
+import { FuzzingRun, RunSeverity } from './types';
 
-interface RunSeverityFilterProps {
+export interface RunSeverityFilterProps {
   value: 'all' | RunSeverity;
   onChange: (value: 'all' | RunSeverity) => void;
+  disabled?: boolean;
 }
 
-const SEVERITY_OPTIONS: Array<'all' | RunSeverity> = ['all', 'low', 'medium', 'high', 'critical'];
+export const SEVERITY_OPTIONS: Array<'all' | RunSeverity> = ['all', 'low', 'medium', 'high', 'critical'];
+
+/**
+ * Returns true if the run matches the given severity filter.
+ * 'all' always matches.
+ */
+export function matchesSeverityFilter(run: FuzzingRun, filter: 'all' | RunSeverity): boolean {
+  if (filter === 'all') return true;
+  return run.severity === filter;
+}
+
+/**
+ * Filters a list of runs by severity.
+ */
+export function filterRunsBySeverity(runs: FuzzingRun[], filter: 'all' | RunSeverity): FuzzingRun[] {
+  if (filter === 'all') return runs;
+  return runs.filter((run) => run.severity === filter);
+}
+
+/**
+ * Returns true if the given string is a valid severity filter value.
+ */
+export function isValidSeverityFilter(value: string): value is 'all' | RunSeverity {
+  return (SEVERITY_OPTIONS as string[]).includes(value);
+}
 
 /**
  * Filter component for selecting run severity.
  */
-export default function RunSeverityFilter({ value, onChange }: RunSeverityFilterProps) {
+export default function RunSeverityFilter({ value, onChange, disabled = false }: RunSeverityFilterProps) {
   return (
     <label className="flex items-center gap-3 group">
       <div className="flex items-center gap-2">
-        <div className="w-1.5 h-1.5 rounded-full bg-blue-500" />
-        <span className="text-zinc-500 dark:text-zinc-400 font-bold uppercase text-[10px] tracking-widest group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">Severity</span>
+        <div className="w-1.5 h-1.5 rounded-full bg-blue-500" aria-hidden="true" />
+        <span className="text-zinc-500 dark:text-zinc-400 font-bold uppercase text-[10px] tracking-widest group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+          Severity
+        </span>
       </div>
       <select
         value={value}
-        onChange={(e) => onChange(e.target.value as any)}
-        className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 px-4 py-2 text-xs font-black uppercase tracking-widest focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-xl shadow-black/5 transition-all cursor-pointer hover:border-zinc-300 dark:hover:border-zinc-700"
+        onChange={(e) => onChange(e.target.value as 'all' | RunSeverity)}
+        disabled={disabled}
+        aria-label="Filter runs by severity"
+        className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 px-4 py-2 text-xs font-black uppercase tracking-widest focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-xl shadow-black/5 transition-all cursor-pointer hover:border-zinc-300 dark:hover:border-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {SEVERITY_OPTIONS.map((opt) => (
           <option key={opt} value={opt} className="bg-white dark:bg-zinc-900 font-bold">
-            {opt === 'all' ? 'All Levels' : opt}
+            {opt === 'all' ? 'All Levels' : opt.charAt(0).toUpperCase() + opt.slice(1)}
           </option>
         ))}
       </select>


### PR DESCRIPTION
- Export filterRunsBySeverity, matchesSeverityFilter, isValidSeverityFilter utilities
- Add aria-label and disabled prop for keyboard accessibility
- Add 18 unit tests covering primary flow and edge cases

Closes #476 

## Summary

Describe what changed and why.

## Linked Issue

Closes #474 

## Validation

- [ ] frontend checks pass (`npm run lint`, `npm run build`)
- [ ] core checks pass (`cargo test`)
- [ ] behavior is reproducible with included steps

## Notes for Maintainers

Any migration, risk, or rollout notes.
