### PR TITLE
feat: integrate run-issue link integration tests

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -3,6 +3,23 @@ This is a [Next.js](https://nextjs.org) dashboard for Soroban CrashLab.
 ## Dashboard Notes
 
 - The home page includes a failure cluster view that groups failed runs by signature and context, then links each group to a representative sample run for triage.
+- Run->issue link integration tests use deterministic boundary contracts in `src/app/integrate-run-issue-link-integration-tests-utils.ts`.
+
+## Run->Issue Link Integration Contract
+
+The integration flow expects four externally provided boundaries:
+
+- `getRunById(runId)`: return run + existing issue links, or `null` if missing.
+- `getEnabledTrackerById(trackerId)`: return enabled tracker config, or `null` if unavailable.
+- `createRunIssueLink(...)`: persist and return created issue link payload.
+- `verifyIssueLink(link)`: return `{ reachable, statusCode }` from downstream issue system.
+
+Failure behavior is explicit and step-based:
+
+- Unknown run -> fail at `run-lookup`
+- Missing/disabled/invalid tracker -> fail at `tracker-lookup` / `tracker-validation`
+- Duplicate run->issue link -> fail at `dedupe-check`
+- Downstream issue endpoint failure (`reachable=false` or `statusCode>=400`) -> fail at `link-verify`
 
 ## Getting Started
 

--- a/apps/web/src/app/integrate-run-issue-link-integration-tests-utils.test.ts
+++ b/apps/web/src/app/integrate-run-issue-link-integration-tests-utils.test.ts
@@ -3,9 +3,12 @@ import {
   buildIssueLink,
   summariseTests,
   toggleTrackerEnabled,
+  runIssueLinkIntegrationFlow,
   IssueTracker,
-  IntegrationTest
+  IntegrationTest,
+  RunIssueLinkDependencies,
 } from './integrate-run-issue-link-integration-tests-utils';
+import type { RunIssueLink } from './types';
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(`Assertion failed: ${message}`);
@@ -85,7 +88,84 @@ function testToggleTrackerEnabled(): void {
   console.log('✓ testToggleTrackerEnabled passed');
 }
 
-function runAllTests(): void {
+function makeDeps(overrides: Partial<RunIssueLinkDependencies> = {}): RunIssueLinkDependencies {
+  const runIssues: RunIssueLink[] = [];
+  return {
+    async getRunById(runId: string) {
+      return runId === 'run-1001' ? { id: runId, issues: runIssues } : null;
+    },
+    async getEnabledTrackerById(trackerId: string) {
+      if (trackerId !== 'gh-1') return null;
+      return makeTracker();
+    },
+    async createRunIssueLink(args) {
+      const link = buildIssueLink(args.tracker, args.issueNumber);
+      runIssues.push(link);
+      return link;
+    },
+    async verifyIssueLink() {
+      return { reachable: true, statusCode: 200 };
+    },
+    ...overrides,
+  };
+}
+
+async function testRunIssueLinkIntegrationFlow_successPath(): Promise<void> {
+  const result = await runIssueLinkIntegrationFlow(
+    { runId: 'run-1001', trackerId: 'gh-1', issueNumber: '411' },
+    makeDeps(),
+  );
+
+  assert(result.success, 'integration flow should succeed');
+  assert(result.link?.href === 'https://github.com/test/repo/issues/411', 'created href should match tracker URL');
+  assert(result.tests.length === 5, 'all deterministic steps should be reported');
+  assert(result.tests.every((step) => step.status === 'passed'), 'all steps should pass');
+  console.log('✓ testRunIssueLinkIntegrationFlow_successPath passed');
+}
+
+async function testRunIssueLinkIntegrationFlow_trackerUnavailable(): Promise<void> {
+  const result = await runIssueLinkIntegrationFlow(
+    { runId: 'run-1001', trackerId: 'missing', issueNumber: '411' },
+    makeDeps(),
+  );
+
+  assert(!result.success, 'flow should fail when tracker cannot be resolved');
+  assert(result.tests.some((step) => step.id === 'tracker-lookup' && step.status === 'failed'), 'tracker lookup should fail');
+  console.log('✓ testRunIssueLinkIntegrationFlow_trackerUnavailable passed');
+}
+
+async function testRunIssueLinkIntegrationFlow_edge_duplicateLink(): Promise<void> {
+  const existing = buildIssueLink(makeTracker(), '411');
+  const result = await runIssueLinkIntegrationFlow(
+    { runId: 'run-1001', trackerId: 'gh-1', issueNumber: '411' },
+    makeDeps({
+      async getRunById(runId: string) {
+        return runId === 'run-1001' ? { id: runId, issues: [existing] } : null;
+      },
+    }),
+  );
+
+  assert(!result.success, 'flow should fail on duplicate run->issue link');
+  assert(result.tests.some((step) => step.id === 'dedupe-check' && step.status === 'failed'), 'duplicate check should fail');
+  console.log('✓ testRunIssueLinkIntegrationFlow_edge_duplicateLink passed');
+}
+
+async function testRunIssueLinkIntegrationFlow_downstreamVerificationFailure(): Promise<void> {
+  const result = await runIssueLinkIntegrationFlow(
+    { runId: 'run-1001', trackerId: 'gh-1', issueNumber: '411' },
+    makeDeps({
+      async verifyIssueLink() {
+        return { reachable: false, statusCode: 503 };
+      },
+    }),
+  );
+
+  assert(!result.success, 'flow should fail when downstream endpoint is unreachable');
+  assert(result.tests.some((step) => step.id === 'link-verify' && step.status === 'failed'), 'verification step should fail');
+  console.log('✓ testRunIssueLinkIntegrationFlow_downstreamVerificationFailure passed');
+}
+
+async function runAllTests(): Promise<void> {
   console.log('Running Run Issue Link Integration Tests Utils Tests...\\n');
   try {
     testValidateTracker_valid();
@@ -95,6 +175,10 @@ function runAllTests(): void {
     testBuildIssueLink();
     testSummariseTests();
     testToggleTrackerEnabled();
+    await testRunIssueLinkIntegrationFlow_successPath();
+    await testRunIssueLinkIntegrationFlow_trackerUnavailable();
+    await testRunIssueLinkIntegrationFlow_edge_duplicateLink();
+    await testRunIssueLinkIntegrationFlow_downstreamVerificationFailure();
     console.log('\\n✅ All Run Issue Link Integration Tests utils tests passed!');
   } catch (error) {
     console.error('\\n❌ Test failed:', error);
@@ -103,5 +187,5 @@ function runAllTests(): void {
 }
 
 if (typeof require !== 'undefined' && require.main === module) {
-  runAllTests();
+  void runAllTests();
 }

--- a/apps/web/src/app/integrate-run-issue-link-integration-tests-utils.ts
+++ b/apps/web/src/app/integrate-run-issue-link-integration-tests-utils.ts
@@ -85,3 +85,129 @@ export function toggleTrackerEnabled(trackers: IssueTracker[], id: string): Issu
     tracker.id === id ? { ...tracker, enabled: !tracker.enabled } : tracker
   );
 }
+
+export interface RunIssueRecord {
+  id: string;
+  issues: RunIssueLink[];
+}
+
+/**
+ * External-system contracts for Run -> issue-link integration.
+ *
+ * Required behavior:
+ * - `getRunById` returns null when the run is unknown.
+ * - `getEnabledTrackerById` returns null when tracker config is missing/disabled.
+ * - `createRunIssueLink` persists or returns the new link for the run.
+ * - `verifyIssueLink` returns reachability details from the downstream issue service.
+ */
+export interface RunIssueLinkDependencies {
+  getRunById(runId: string): Promise<RunIssueRecord | null>;
+  getEnabledTrackerById(trackerId: string): Promise<IssueTracker | null>;
+  createRunIssueLink(args: {
+    runId: string;
+    tracker: IssueTracker;
+    issueNumber: string;
+  }): Promise<RunIssueLink>;
+  verifyIssueLink(link: RunIssueLink): Promise<{ reachable: boolean; statusCode: number }>;
+}
+
+export interface RunIssueLinkFlowInput {
+  runId: string;
+  trackerId: string;
+  issueNumber: string;
+}
+
+export interface RunIssueLinkFlowResult {
+  success: boolean;
+  link?: RunIssueLink;
+  tests: IntegrationTest[];
+}
+
+function passStep(id: string, name: string): IntegrationTest {
+  return { id, name, status: "passed" };
+}
+
+function failStep(id: string, name: string, error: string): IntegrationTest {
+  return { id, name, status: "failed", error };
+}
+
+/**
+ * Deterministic integration-flow test runner for Run -> issue linking.
+ *
+ * This function executes the same boundary checks a maintainer would verify
+ * manually, but in a reproducible order with explicit failed-step reporting.
+ */
+export async function runIssueLinkIntegrationFlow(
+  input: RunIssueLinkFlowInput,
+  deps: RunIssueLinkDependencies,
+): Promise<RunIssueLinkFlowResult> {
+  const tests: IntegrationTest[] = [];
+
+  if (!input.runId || !input.trackerId || !input.issueNumber) {
+    tests.push(
+      failStep("config-validation", "Validate integration input", "Missing runId, trackerId, or issueNumber"),
+    );
+    return { success: false, tests };
+  }
+
+  const run = await deps.getRunById(input.runId);
+  if (!run) {
+    tests.push(failStep("run-lookup", "Resolve run by ID", `Run ${input.runId} not found`));
+    return { success: false, tests };
+  }
+  tests.push(passStep("run-lookup", "Resolve run by ID"));
+
+  const tracker = await deps.getEnabledTrackerById(input.trackerId);
+  if (!tracker) {
+    tests.push(failStep("tracker-lookup", "Resolve enabled tracker", `Tracker ${input.trackerId} is unavailable`));
+    return { success: false, tests };
+  }
+
+  const trackerValidation = validateTracker(tracker);
+  if (!trackerValidation.isValid || !tracker.enabled) {
+    tests.push(
+      failStep(
+        "tracker-validation",
+        "Validate tracker configuration",
+        trackerValidation.errors[0] ?? "Tracker must be enabled",
+      ),
+    );
+    return { success: false, tests };
+  }
+  tests.push(passStep("tracker-validation", "Validate tracker configuration"));
+
+  const expectedLink = buildIssueLink(tracker, input.issueNumber);
+  if (run.issues.some((issue) => issue.href === expectedLink.href)) {
+    tests.push(
+      failStep("dedupe-check", "Check duplicate run->issue link", "Issue link already attached to run"),
+    );
+    return { success: false, tests };
+  }
+  tests.push(passStep("dedupe-check", "Check duplicate run->issue link"));
+
+  const created = await deps.createRunIssueLink({
+    runId: run.id,
+    tracker,
+    issueNumber: input.issueNumber,
+  });
+  if (!created?.href || !created?.label) {
+    tests.push(failStep("link-create", "Persist run->issue link", "Created link payload is incomplete"));
+    return { success: false, tests };
+  }
+  tests.push(passStep("link-create", "Persist run->issue link"));
+
+  const verification = await deps.verifyIssueLink(created);
+  if (!verification.reachable || verification.statusCode >= 400) {
+    tests.push(
+      failStep(
+        "link-verify",
+        "Verify downstream issue endpoint",
+        `Downstream status ${verification.statusCode}`,
+      ),
+    );
+    return { success: false, link: created, tests };
+  }
+  tests.push(passStep("link-verify", "Verify downstream issue endpoint"));
+
+  return { success: true, link: created, tests };
+}


### PR DESCRIPTION
## Summary
- Added deterministic Run->issue link integration-flow testing utilities to verify cross-boundary behavior end-to-end.
- Implemented explicit boundary contracts for run lookup, tracker lookup, link persistence, and downstream link verification.
- Kept scope focused on integration-test flow + edge/failure behavior for run->issue linking; no unrelated UI/feature changes were introduced.

## Implementation Notes
- Primary files changed:
  - `apps/web/src/app/integrate-run-issue-link-integration-tests-utils.ts`
  - `apps/web/src/app/integrate-run-issue-link-integration-tests-utils.test.ts`
  - `apps/web/README.md`
- Added `runIssueLinkIntegrationFlow(...)` with deterministic step reporting:
  - `run-lookup`
  - `tracker-validation`
  - `dedupe-check`
  - `link-create`
  - `link-verify`
- External dependency/config contract documented in README:
  - `getRunById`
  - `getEnabledTrackerById`
  - `createRunIssueLink`
  - `verifyIssueLink`
- Security/reliability notes:
  - Explicit failure surface for missing run, unavailable/invalid tracker, duplicate link, and downstream verification failure.
  - Integration drift becomes observable through deterministic failed-step outputs.

## Validation
- `cd apps/web && npx tsc src/app/integrate-run-issue-link-integration-tests-utils.ts src/app/integrate-run-issue-link-integration-tests-utils.test.ts src/app/types.ts --module commonjs --target es2020 --outDir build/test-tmp --esModuleInterop && node build/test-tmp/integrate-run-issue-link-integration-tests-utils.test.js` -> PASS
- `cd apps/web && npm run test` -> PASS (includes updated run->issue integration tests)
- `cd apps/web && npm run lint` -> FAIL (unrelated pre-existing errors in other files; none from changed files)
- `cd apps/web && npm run build` -> FAIL (unrelated pre-existing compile/build errors in other files; none from changed files)
- Merge conflict dry-run against `upstream/main`: **Automatic merge went well**

## Repro Steps for Maintainer
1. Check out branch `feat/wave4-integrate-run-issue-link-integration-tests`.
2. Run the targeted integration module checks:
   - `cd apps/web`
   - `npx tsc src/app/integrate-run-issue-link-integration-tests-utils.ts src/app/integrate-run-issue-link-integration-tests-utils.test.ts src/app/types.ts --module commonjs --target es2020 --outDir build/test-tmp --esModuleInterop`
   - `node build/test-tmp/integrate-run-issue-link-integration-tests-utils.test.js`
3. Confirm deterministic pass/fail behavior for:
   - success path
   - tracker unavailable
   - duplicate link edge case
   - downstream verification failure

## Risks / Follow-ups
- Repository currently has unrelated existing lint/build failures outside this issue scope, which can affect full quality-gate status.
- Optional follow-up: add these new integration checks to a dedicated CI-targeted script for scoped gating.

Closes #411