### PR TITLE
feat: implement frontend UI components (#493 #494 #495 #496)

### DIFF
--- a/apps/web/src/app/implement-resource-fee-insight-panel-component.tsx
+++ b/apps/web/src/app/implement-resource-fee-insight-panel-component.tsx
@@ -42,66 +42,6 @@ interface ResourceFeeStats {
   };
 }
 
-function calculateGroupStats(groupRuns: FuzzingRun[]) {
-  const fees = groupRuns.map(run => run.minResourceFee).filter(fee => fee > 0);
-  return {
-    averageFee: fees.length > 0 ? fees.reduce((sum, fee) => sum + fee, 0) / fees.length : 0,
-    totalRuns: groupRuns.length,
-    totalFees: fees.reduce((sum, fee) => sum + fee, 0)
-  };
-}
-
-function getWeekString(date: Date) {
-  const year = date.getFullYear();
-  const week = Math.ceil((date.getTime() - new Date(year, 0, 1).getTime()) / (7 * 24 * 60 * 60 * 1000));
-  return `${year}-W${week.toString().padStart(2, '0')}`;
-}
-
-function calculateTrends(filteredRuns: FuzzingRun[]) {
-  const dailyData = new Map<string, { fees: number[]; count: number }>();
-  const weeklyData = new Map<string, { fees: number[]; count: number }>();
-
-  filteredRuns.forEach(run => {
-    const date = new Date(run.startedAt || run.queuedAt || '');
-    const dateStr = date.toISOString().split('T')[0];
-    const weekStr = getWeekString(date);
-
-    if (!dailyData.has(dateStr)) {
-      dailyData.set(dateStr, { fees: [], count: 0 });
-    }
-    if (!weeklyData.has(weekStr)) {
-      weeklyData.set(weekStr, { fees: [], count: 0 });
-    }
-
-    if (run.minResourceFee > 0) {
-      dailyData.get(dateStr)!.fees.push(run.minResourceFee);
-      weeklyData.get(weekStr)!.fees.push(run.minResourceFee);
-    }
-    dailyData.get(dateStr)!.count++;
-    weeklyData.get(weekStr)!.count++;
-  });
-
-  const daily = Array.from(dailyData.entries())
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .slice(-30)
-    .map(([date, data]) => ({
-      date,
-      averageFee: data.fees.length > 0 ? data.fees.reduce((sum, fee) => sum + fee, 0) / data.fees.length : 0,
-      runCount: data.count
-    }));
-
-  const weekly = Array.from(weeklyData.entries())
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .slice(-12)
-    .map(([week, data]) => ({
-      week,
-      averageFee: data.fees.length > 0 ? data.fees.reduce((sum, fee) => sum + fee, 0) / data.fees.length : 0,
-      runCount: data.count
-    }));
-
-  return { daily, weekly };
-}
-
 const ResourceFeeInsightPanel: React.FC<ResourceFeeInsightPanelProps> = ({
   runs,
   className = '',

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -64,6 +64,7 @@ import BulkActionsForRuns, { BulkAction } from "./add-bulk-actions-for-runs";
 import AddDownloadableRunArtifactBundle from "./add-downloadable-run-artifact-bundle";
 import CampaignConfigForm from "./CampaignConfigForm";
 import { CampaignConfig } from "./types";
+import ResourceFeeInsightPanel from "./implement-resource-fee-insight-panel-component";
 
 // Mock data for demonstration
 const MOCK_RUNS: FuzzingRun[] = Array.from({ length: 25 }, (_, i) => ({
@@ -1032,6 +1033,10 @@ function HomeContent() {
 
           <div className="mb-12 w-full">
             <AddRunComparisonCharts runs={filteredRuns} />
+          </div>
+
+          <div className="mb-12 w-full">
+            <ResourceFeeInsightPanel runs={filteredRuns} />
           </div>
 
           <div className="mb-12 w-full">


### PR DESCRIPTION
Closes #496

---

Closes #493

---

Closes #494

---

Closes #495

---


## Summary

- **#493 Log viewer component** — Already fully implemented in `implement-log-viewer-component.tsx` and mounted in the dashboard (`page.tsx:710`). No changes needed.
- **#494 Resource fee insight panel** — Component was implemented in `implement-resource-fee-insight-panel-component.tsx` but never imported or mounted. This PR wires it into the dashboard after the run comparison charts section.
- **#495 Run history table** — Already fully implemented in `implement-run-history-table-component.tsx` and used as the primary run table in the dashboard. No changes needed.
- **#496 Widget layout editor** — Already fully implemented in `implement-widget-layout-editor-component.tsx` and mounted in the dashboard (`page.tsx:1096`). No changes needed.

Also removes 60 lines of duplicate module-level helper functions (`calculateGroupStats`, `getWeekString`, `calculateTrends`) from the resource fee panel that shadowed identical inner-component definitions, which would have caused TypeScript/lint errors.

## Test plan

- [ ] Visit the dashboard — all four components should render
- [ ] ResourceFeeInsightPanel appears in the analytics section with Overview/Trends/Breakdown tabs
- [ ] LogViewer streams simulated logs with pause/filter/search controls
- [ ] RunHistoryTable shows sortable run rows with inspect/report actions
- [ ] WidgetLayoutEditor is visible when maintainer mode is enabled


