### PR TITLE
feat: add PrngMutator adapter, container stress edge tests, lint-fixtures and crash-index CLIs

### DIFF
--- a/contracts/crashlab-core/Cargo.toml
+++ b/contracts/crashlab-core/Cargo.toml
@@ -22,3 +22,11 @@ path = "src/bin/import-corpus.rs"
 [[bin]]
 name = "check-fixtures"
 path = "src/bin/check-fixtures.rs"
+
+[[bin]]
+name = "lint-fixtures"
+path = "src/bin/lint-fixtures.rs"
+
+[[bin]]
+name = "crash-index"
+path = "src/bin/crash-index.rs"

--- a/contracts/crashlab-core/src/bin/crash-index.rs
+++ b/contracts/crashlab-core/src/bin/crash-index.rs
@@ -1,0 +1,53 @@
+//! CLI: build a dedup index from crash bundles and report grouped counts.
+//!
+//! Reads one or more [`CaseBundleDocument`] JSON files, indexes them by
+//! signature hash via [`CrashIndex`], and prints a grouped summary table.
+//!
+//! # Usage
+//! ```text
+//! crash-index <bundle.json> [bundle2.json ...]
+//! ```
+//!
+//! # Exit codes
+//! - `0` — summary printed successfully.
+//! - `2` — a file could not be read or parsed.
+
+use crashlab_core::{CrashIndex, load_case_bundle_json};
+
+fn main() {
+    let paths: Vec<String> = std::env::args().skip(1).collect();
+
+    if paths.is_empty() {
+        eprintln!("usage: crash-index <bundle.json> [bundle2.json ...]");
+        std::process::exit(2);
+    }
+
+    let mut index = CrashIndex::new();
+
+    for path in &paths {
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("error: cannot read {path}: {e}");
+                std::process::exit(2);
+            }
+        };
+
+        let bundle = match load_case_bundle_json(&bytes) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("error: cannot parse {path}: {e}");
+                std::process::exit(2);
+            }
+        };
+
+        index.insert(bundle);
+    }
+
+    let summary = index.summary();
+    print!("{}", summary.to_cli_table());
+    println!(
+        "--- {} unique signature(s), {} total crash(es) ---",
+        summary.unique_signatures, summary.total_crashes
+    );
+}

--- a/contracts/crashlab-core/src/bin/lint-fixtures.rs
+++ b/contracts/crashlab-core/src/bin/lint-fixtures.rs
@@ -1,0 +1,89 @@
+//! CLI: lint fixture manifests for schema, naming, and duplicate IDs.
+//!
+//! Reads one or more [`FixtureManifest`] JSON files, runs [`FixtureLinter`]
+//! checks on every entry, and exits non-zero when errors are found.
+//!
+//! # Usage
+//! ```text
+//! lint-fixtures <manifest.json> [manifest2.json ...]
+//! ```
+//!
+//! # Exit codes
+//! - `0` — all fixtures pass linting.
+//! - `1` — at least one lint error or critical issue was found.
+//! - `2` — a file could not be read or parsed.
+
+use crashlab_core::{FixtureLinter, LintLevel};
+use crashlab_core::fixture_manifest::FixtureManifest;
+
+fn main() {
+    let paths: Vec<String> = std::env::args().skip(1).collect();
+
+    if paths.is_empty() {
+        eprintln!("usage: lint-fixtures <manifest.json> [manifest2.json ...]");
+        std::process::exit(2);
+    }
+
+    let linter = FixtureLinter::new();
+    let mut all_ids: Vec<String> = Vec::new();
+    let mut error_count = 0usize;
+    let mut parse_error = false;
+
+    for path in &paths {
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("error: cannot read {path}: {e}");
+                parse_error = true;
+                continue;
+            }
+        };
+
+        let manifest: FixtureManifest = match serde_json::from_slice(&bytes) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("error: cannot parse {path}: {e}");
+                parse_error = true;
+                continue;
+            }
+        };
+
+        for meta in manifest.fixtures.values() {
+            let report = linter.lint_metadata(
+                &meta.id,
+                &meta.fixture_type,
+                meta.failure_category.as_deref(),
+            );
+
+            for issue in &report.issues {
+                println!("[{}] {} (fixture: {})", issue.level, issue.message, meta.id);
+                if issue.level >= LintLevel::Error {
+                    error_count += 1;
+                }
+            }
+
+            all_ids.push(meta.id.clone());
+        }
+    }
+
+    // Check for duplicate IDs across all manifests.
+    let id_refs: Vec<&str> = all_ids.iter().map(String::as_str).collect();
+    let dup_report = linter.check_duplicate_ids(&id_refs);
+    for issue in &dup_report.issues {
+        println!("[{}] {}", issue.level, issue.message);
+        if issue.level >= LintLevel::Error {
+            error_count += 1;
+        }
+    }
+
+    if parse_error {
+        std::process::exit(2);
+    }
+
+    if error_count > 0 {
+        eprintln!("lint failed: {error_count} error(s) found across {} fixture(s).", all_ids.len());
+        std::process::exit(1);
+    }
+
+    println!("ok — {} fixture(s) passed linting.", all_ids.len());
+}

--- a/contracts/crashlab-core/src/container_stress.rs
+++ b/contracts/crashlab-core/src/container_stress.rs
@@ -230,4 +230,49 @@ mod tests {
         let b = generate_container_stress_grid(100, &cfg);
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn fixed_vec_size_when_min_equals_max() {
+        // When min == max there is exactly one valid vec size.
+        let cfg = ContainerStressConfig::new(7, 7, 0, 10);
+        let m = ContainerStressMutator::new(cfg);
+        let seed = CaseSeed { id: 3, payload: vec![0u8; 8] };
+        for r in 0..40u64 {
+            let mut rng = r;
+            let out = m.mutate(&seed, &mut rng);
+            if out.payload[0] == 0xD0 {
+                let vec_sz = u64::from_le_bytes(out.payload[1..9].try_into().unwrap());
+                assert_eq!(vec_sz, 7, "vec size must be exactly 7 when min==max");
+            }
+        }
+    }
+
+    #[test]
+    fn fixed_map_size_when_min_equals_max() {
+        let cfg = ContainerStressConfig::new(0, 5, 13, 13);
+        let m = ContainerStressMutator::new(cfg);
+        let seed = CaseSeed { id: 8, payload: vec![0u8; 8] };
+        for r in 0..40u64 {
+            let mut rng = r.wrapping_mul(0xDEAD);
+            let out = m.mutate(&seed, &mut rng);
+            if out.payload[0] == 0xD1 {
+                let map_sz = u64::from_le_bytes(out.payload[1..9].try_into().unwrap());
+                assert_eq!(map_sz, 13, "map size must be exactly 13 when min==max");
+            }
+        }
+    }
+
+    #[test]
+    fn zero_max_clamps_to_zero() {
+        // Both vec and map max are 0; all sizes must be 0.
+        let cfg = ContainerStressConfig::new(0, 0, 0, 0);
+        let m = ContainerStressMutator::new(cfg);
+        let seed = CaseSeed { id: 1, payload: vec![0xAA; 4] };
+        for r in 0..20u64 {
+            let mut rng = r;
+            let out = m.mutate(&seed, &mut rng);
+            let primary = u64::from_le_bytes(out.payload[1..9].try_into().unwrap());
+            assert_eq!(primary, 0, "primary size must be 0 when max is 0");
+        }
+    }
 }

--- a/contracts/crashlab-core/src/lib.rs
+++ b/contracts/crashlab-core/src/lib.rs
@@ -13,7 +13,7 @@ pub use auth_matrix::{
 pub use health::{
     FailureMetrics, HealthMonitor, HealthStatus, HealthSummary, QueueMetrics, ThroughputMetrics,
 };
-pub use prng::SeededPrng;
+pub use prng::{PrngMutator, SeededPrng};
 pub use reproducer::{
     FlakyDetector, ReproReport, filter_ci_pack, shrink_bundle_payload,
     shrink_seed_preserving_signature,

--- a/contracts/crashlab-core/src/prng.rs
+++ b/contracts/crashlab-core/src/prng.rs
@@ -1,3 +1,6 @@
+use crate::scheduler::Mutator;
+use crate::CaseSeed;
+
 /// Deterministic pseudo-random number generator keyed by a seed ID.
 ///
 /// Uses the xorshift64* algorithm, which is fully deterministic for a given
@@ -66,6 +69,31 @@ impl SeededPrng {
     }
 }
 
+/// [`Mutator`] adapter that drives mutations through [`SeededPrng`].
+///
+/// Blends `seed.id` with the caller-supplied `rng_state` so the same seed
+/// produces different outputs across scheduler iterations while remaining fully
+/// reproducible for a fixed `(seed.id, rng_state)` pair.
+pub struct PrngMutator;
+
+impl Mutator for PrngMutator {
+    fn name(&self) -> &'static str {
+        "prng"
+    }
+
+    fn mutate(&self, seed: &CaseSeed, rng_state: &mut u64) -> CaseSeed {
+        let blended = seed.id ^ *rng_state;
+        let mut prng = SeededPrng::new(blended);
+        // Advance rng_state so successive scheduler calls get fresh entropy.
+        *rng_state = prng.next_u64();
+        let len = seed.payload.len().max(1);
+        CaseSeed {
+            id: seed.id,
+            payload: prng.mutation_stream(len),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,5 +134,54 @@ mod tests {
         let mut a = SeededPrng::new(u64::MAX);
         let mut b = SeededPrng::new(u64::MAX);
         assert_eq!(a.mutation_stream(20), b.mutation_stream(20));
+    }
+
+    #[test]
+    fn prng_mutator_is_deterministic_for_same_inputs() {
+        let m = PrngMutator;
+        let seed = CaseSeed { id: 5, payload: vec![1, 2, 3] };
+        let a = m.mutate(&seed, &mut 42u64);
+        let b = m.mutate(&seed, &mut 42u64);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn prng_mutator_different_rng_states_produce_different_outputs() {
+        let m = PrngMutator;
+        let seed = CaseSeed { id: 5, payload: vec![1, 2, 3] };
+        let a = m.mutate(&seed, &mut 1u64);
+        let b = m.mutate(&seed, &mut 2u64);
+        assert_ne!(a.payload, b.payload);
+    }
+
+    #[test]
+    fn prng_mutator_advances_rng_state() {
+        let m = PrngMutator;
+        let seed = CaseSeed { id: 1, payload: vec![0] };
+        let mut rng = 99u64;
+        let before = rng;
+        m.mutate(&seed, &mut rng);
+        assert_ne!(rng, before);
+    }
+
+    #[test]
+    fn prng_mutator_empty_payload_produces_one_byte() {
+        let m = PrngMutator;
+        let seed = CaseSeed { id: 7, payload: vec![] };
+        let out = m.mutate(&seed, &mut 0u64);
+        assert_eq!(out.payload.len(), 1);
+    }
+
+    #[test]
+    fn prng_mutator_preserves_seed_id() {
+        let m = PrngMutator;
+        let seed = CaseSeed { id: 42, payload: vec![0xFF; 8] };
+        let out = m.mutate(&seed, &mut 0u64);
+        assert_eq!(out.id, 42);
+    }
+
+    #[test]
+    fn prng_mutator_name() {
+        assert_eq!(PrngMutator.name(), "prng");
     }
 }


### PR DESCRIPTION
## Summary

- **#387 – deterministic PRNG adapter**: `SeededPrng` existed but lacked a `Mutator` implementation. Added `PrngMutator` which blends `seed.id` with `rng_state` for varied-yet-reproducible mutations, exports `PrngMutator` from `lib.rs`, and ships 6 focused tests covering determinism, rng-state advancement, empty payload, and identity preservation.
- **#388 – vec/map size stress mutator**: Core implementation was already present. Added three missing edge-case tests to `ContainerStressMutator`: `min==max` fixed vec size, `min==max` fixed map size, and `max==0` zero-clamp — covering the full bounds of the configurable min/max acceptance criteria.
- **#391 – fixture lint command**: `FixtureLinter` existed as a library type but had no CLI surface. Added `src/bin/lint-fixtures.rs` which reads one or more `FixtureManifest` JSON files, lints each fixture entry for schema/naming conventions, checks cross-manifest duplicate IDs, and exits non-zero on errors.
- **#394 – duplicate crash de-dup index**: `CrashIndex` existed as a library type but had no CLI surface. Added `src/bin/crash-index.rs` which reads `CaseBundleDocument` JSON files, builds a `CrashIndex`, and prints the grouped dedup summary table via `CrashIndexSummary::to_cli_table()`.

## Linked Issues

Closes #387
Closes #388
Closes #391
Closes #394
