### PR TITLE
chore: foundation prep and roadmap issue automation

### DIFF
--- a/scripts/roadmap/create_github_issues.sh
+++ b/scripts/roadmap/create_github_issues.sh
@@ -17,39 +17,45 @@ fi
 
 echo "Creating milestones..."
 for title in "P0 Foundation" "P1 Data bridge" "P2 Product UI" "P3 Integrations" "P4 Hardening" "P5 Documentation"; do
-  gh api "repos/${REPO}/milestones" -f title="$title" -f state=open 2>/dev/null \
-    || gh api "repos/${REPO}/milestones" --jq ".[] | select(.title==\"$title\") | .number" | head -1 >/dev/null || true
+  if ! gh api "repos/${REPO}/milestones" --jq ".[].title" | grep -Fxq "$title"; then
+    gh api "repos/${REPO}/milestones" -f title="$title" -f state=open >/dev/null
+  fi
 done
-
-milestone_number() {
-  local title="$1"
-  gh api "repos/${REPO}/milestones" --jq ".[] | select(.title==\"${title}\") | .number" | head -1
-}
 
 count=$(jq '.count' "$CATALOG")
 echo "Creating ${count} issues on ${REPO}..."
 
 created=0
+index=0
 while read -r row; do
+  index=$((index + 1))
   title=$(jq -r '.title' <<<"$row")
   body=$(jq -r '.body' <<<"$row")
   milestone=$(jq -r '.milestone' <<<"$row")
-  ms_num=$(milestone_number "$milestone")
+  roadmap_id=$(jq -r '.roadmap_id' <<<"$row")
 
   label_args=()
   while IFS= read -r label; do
     [[ -n "$label" ]] && label_args+=(--label "$label")
   done < <(jq -r '.labels[]' <<<"$row")
 
-  issue_url=$(gh issue create \
+  if gh issue list --repo "$REPO" --search "ROADMAP-$(printf '%03d' "$roadmap_id") in:body" --limit 1 --json number --jq '.[0].number' 2>/dev/null | grep -q .; then
+    echo "[$index/$count] skip ROADMAP-$(printf '%03d' "$roadmap_id") (exists)"
+    continue
+  fi
+
+  if ! issue_url=$(gh issue create \
     --repo "$REPO" \
     --title "$title" \
     --body "$body" \
     "${label_args[@]}" \
-    ${ms_num:+--milestone "$ms_num"} 2>&1)
+    --milestone "$milestone"); then
+    echo "Failed: $title" >&2
+    exit 1
+  fi
 
   created=$((created + 1))
-  echo "[$created/$count] $title -> $issue_url"
+  echo "[$index/$count] $title -> $issue_url"
   sleep 0.35
 done < <(jq -c '.issues[]' "$CATALOG")
 


### PR DESCRIPTION
## Summary
- Shared artifact API store, settings stub routes, dashboard a11y/layout fixes
- Roadmap generator (`scripts/roadmap/`) for 140 GitHub issues with labels/milestones
- Issue template, PR template, ops backlog pointer

## Related
Roadmap issues **#587–#727** (label: `roadmap`) — merge this before contributors start P0.

## Test plan
- [x] `npm run build` in apps/web
- [x] Labels + 140 issues created on org repo

Made with [Cursor](https://cursor.com)