### PR TITLE
fix(contracts): centralize signature construction and re-enable tests (ROADMAP-001/002/003/004)

### DIFF
--- a/contracts/crashlab-core/src/lib.rs
+++ b/contracts/crashlab-core/src/lib.rs
@@ -29,6 +29,7 @@ pub use signature_hash::{SignatureHasher, hash_category_payload};
 pub use taxonomy::{
     FailureClass, classify_failure, group_by_class, stable_failure_class_for_bundle,
 };
+pub use taxonomy::crash_signature_from_seed;
 pub use regression_group::RegressionGroup;
 pub use fixture::RegressionFixture;
 pub use fixture_classifier::{classify_fixture, classify_and_wrap_fixture};
@@ -194,9 +195,10 @@ pub use rpc_envelope::{RpcEnvelopeCapture, RpcRequestEnvelope, RpcResponseEnvelo
 
 pub mod stellar_address;
 
-// TODO: threat_model_tests.rs has outdated API calls and needs refactoring
-// #[cfg(test)]
-// mod threat_model_tests;
+// Re-enable threat model tests (compile-only pass). Obsolete cases can be
+// ignored or updated as follow-ups (see ROADMAP-004).
+#[cfg(test)]
+mod threat_model_tests;
 pub use stellar_address::{
     AddressMutatorConfig, AddressType, StellarAddressMutator, generate_address_vectors,
 };
@@ -236,15 +238,9 @@ pub struct CrashSignature {
 /// The hash is deterministic and independent of any seed ID, so equivalent
 /// failures always produce the same value.
 pub fn compute_signature_hash(category: &str, payload: &[u8]) -> u64 {
-    const FNV_OFFSET: u64 = 14695981039346656037;
-    const FNV_PRIME: u64 = 1099511628211;
-
-    let mut hash = FNV_OFFSET;
-    for byte in category.as_bytes().iter().chain(payload.iter()) {
-        hash ^= *byte as u64;
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    hash
+    // Delegate to the centralized signature hashing implementation so the
+    // hashing format remains stable and consistent across callers.
+    signature_hash::hash_category_payload(category, payload)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -280,27 +276,10 @@ pub fn mutate_seed(seed: &CaseSeed) -> CaseSeed {
 }
 
 pub fn classify(seed: &CaseSeed) -> CrashSignature {
-    let digest = seed.payload.iter().fold(seed.id, |acc, b| {
-        acc.wrapping_mul(1099511628211).wrapping_add(*b as u64)
-    });
-
-    let category = if seed.payload.is_empty() {
-        "empty-input"
-    } else if seed.payload.len() > 64 {
-        "oversized-input"
-    } else if is_invalid_enum_tag_payload(&seed.payload) {
-        "invalid-enum-tag"
-    } else {
-        "runtime-failure"
-    };
-
-    let signature_hash = compute_signature_hash(category, &seed.payload);
-
-    CrashSignature {
-        category: category.to_string(),
-        digest,
-        signature_hash,
-    }
+    // Delegate signature construction to the taxonomy helper which produces
+    // category labels consistent with `classify_failure` and a centralized
+    // signature hashing strategy.
+    taxonomy::crash_signature_from_seed(seed)
 }
 
 pub fn to_bundle(seed: CaseSeed) -> CaseBundle {

--- a/contracts/crashlab-core/src/taxonomy.rs
+++ b/contracts/crashlab-core/src/taxonomy.rs
@@ -191,6 +191,32 @@ pub fn stable_failure_class_for_bundle(
     })
 }
 
+/// Build a `CrashSignature` from a seed using only the taxonomy mapping.
+///
+/// This central helper produces the stable `category` label, computes the
+/// deterministic `digest` and derives a `signature_hash` using the
+/// `signature_hash` helper. It is intended to be the single place that
+/// constructs `CrashSignature` values from raw seed bytes so callers (e.g.
+/// `to_bundle`) remain consistent with the taxonomy.
+pub fn crash_signature_from_seed(seed: &CaseSeed) -> CrashSignature {
+    let class = classify_failure(seed);
+    let category = class.as_str().to_string();
+
+    // Preserve the existing digest algorithm used by callers.
+    let digest = seed.payload.iter().fold(seed.id, |acc, b| {
+        acc.wrapping_mul(1099511628211).wrapping_add(*b as u64)
+    });
+
+    // Use the signature hashing helper so hashing logic is centralized.
+    let signature_hash = crate::signature_hash::hash_category_payload(category.as_str(), &seed.payload);
+
+    CrashSignature {
+        category,
+        digest,
+        signature_hash,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contracts/crashlab-core/src/threat_model_tests.rs
+++ b/contracts/crashlab-core/src/threat_model_tests.rs
@@ -25,16 +25,19 @@ mod threat_model_tests {
 
     #[test]
     fn failure_class_as_str_is_filesystem_safe() {
+        // Use the current `FailureClass` variants. Obsolete categories were
+        // removed during taxonomy rollout; keep this test focused on the
+        // filesystem-safety of the stable labels.
         let classes = [
             FailureClass::Auth,
             FailureClass::Budget,
-            FailureClass::Storage,
-            FailureClass::Arithmetic,
-            FailureClass::Context,
-            FailureClass::Object,
-            FailureClass::Crypto,
-            FailureClass::Events,
+            FailureClass::State,
+            FailureClass::Xdr,
+            FailureClass::InvalidEnumTag,
+            FailureClass::EmptyInput,
+            FailureClass::OversizedInput,
             FailureClass::Unknown,
+            FailureClass::Timeout,
         ];
 
         for class in classes {


### PR DESCRIPTION
This PR centralizes CrashSignature construction and signature hashing, unifies classification with the taxonomy, and re-enables the threat model test module (compile-pass). It also updates tests to use the current `FailureClass` variants.

Changes:
- Add `taxonomy::crash_signature_from_seed` helper to build `CrashSignature` from a seed using taxonomy-only logic.
- Delegate `classify()` in `lib.rs` to the new helper.
- Delegate `compute_signature_hash()` to the centralized `signature_hash` helper.
- Re-enable `threat_model_tests` and update obsolete variants so the module compiles.

Closes #587
Closes #588
Closes #589
Closes #590