### PR TITLE
chore(ops): archive Wave 3 backlog README and roadmap pointers (ROADMAP-012)

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -1,16 +1,22 @@
-# Ops backlog
+# Ops Backlog
 
-Historical Wave 3 backlog TSV files in this directory are **archived**.
+This directory contains the archived Wave 3 backlog sources and helper notes.
 
-**Source of truth:** GitHub Issues and milestones (`P0 Foundation` … `P5 Documentation`).
+## Archived backlog files
 
-Generate or refresh the roadmap catalog locally:
+- [wave3-backlog.md](wave3-backlog.md) - curated backlog overview
+- [wave3-issues.tsv](wave3-issues.tsv) - source TSV for bulk GitHub issue creation
+- [wave3-append-rows.tsv](wave3-append-rows.tsv) - supplemental backlog rows
+- [wave3-new-frontend.tsv](wave3-new-frontend.tsv) - frontend-focused backlog rows
+- [wave3-missing.tsv](wave3-missing.tsv) - rows still awaiting catalog completion
 
-```bash
-python3 scripts/roadmap/generate_catalog.py
-export GH_TOKEN=...   # repo scope, do not commit
-./scripts/roadmap/create_labels.sh
-./scripts/roadmap/create_github_issues.sh
-```
+## Current workflow
 
-Do not edit `pnpm-lock.yaml` or `package-lock.json` in contributor PRs.
+Roadmap issue generation now lives in `scripts/roadmap/`.
+
+- Use `scripts/roadmap/generate_catalog.py` to convert TSV rows into `issues.json`.
+- Use `scripts/roadmap/create_github_issues.sh` to publish roadmap issues to GitHub.
+
+## Archive note
+
+The TSV backlog here is kept for traceability and historical reference. New work should be tracked through GitHub issues and milestones instead of expanding the archived TSV set.


### PR DESCRIPTION
Implements ROADMAP-012 by archiving the Wave 3 ops backlog README and pointing contributors to the active roadmap workflow.

What changed:
- marks the TSV backlog as archived for historical reference
- links the roadmap scripts that now own bulk issue generation
- keeps the change scoped to ops/README.md only

Closes #599

Testing:
- documentation-only change