### PR TITLE
feat(api): implement GET /api/runs/[id] (ROADMAP-032)

### DIFF
--- a/apps/web/src/app/api/runs/[id]/route.ts
+++ b/apps/web/src/app/api/runs/[id]/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildMockRuns } from '@/app/mockRuns';
+import type { FuzzingRun } from '@/app/types';
+
+/**
+ * Resolves a single run by ID from the in-process mock store.
+ * Exported for unit testing without the Next.js request layer.
+ */
+export function findRunById(id: string): FuzzingRun | undefined {
+  return buildMockRuns().find((r) => r.id === id);
+}
+
+/**
+ * GET /api/runs/[id]
+ *
+ * When RUNS_API_URL is set the request is forwarded to the Rust backend at
+ * `${RUNS_API_URL}/runs/<id>`.  Otherwise the response is served from the
+ * in-process mock dataset so the frontend stays functional without the backend.
+ *
+ * Env vars:
+ *   RUNS_API_URL  – base URL of the Rust fuzzer API (e.g. http://localhost:8080)
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+
+    if (!id) {
+      return NextResponse.json({ error: 'Run ID is required' }, { status: 400 });
+    }
+
+    const runsApiUrl = process.env.RUNS_API_URL;
+
+    if (runsApiUrl) {
+      const upstream = await fetch(
+        `${runsApiUrl}/runs/${encodeURIComponent(id)}`,
+        { headers: { Accept: 'application/json' } },
+      );
+      if (upstream.status === 404) {
+        return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+      }
+      if (!upstream.ok) {
+        return NextResponse.json({ error: 'Upstream error' }, { status: 502 });
+      }
+      const data = (await upstream.json()) as unknown;
+      return NextResponse.json(data);
+    }
+
+    const run = findRunById(id);
+    if (!run) {
+      return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+    }
+    return NextResponse.json(run);
+  } catch (error) {
+    console.error('GET /api/runs/[id] failed:', error);
+    return NextResponse.json({ error: 'Failed to fetch run' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/runs/get-run-by-id.test.ts
+++ b/apps/web/src/app/api/runs/get-run-by-id.test.ts
@@ -1,0 +1,60 @@
+import * as assert from 'node:assert/strict';
+import { buildMockRuns } from '../mockRuns';
+import type { FuzzingRun } from '../types';
+
+const VALID_STATUSES = new Set(['running', 'completed', 'failed', 'cancelled']);
+const VALID_AREAS = new Set(['auth', 'state', 'budget', 'xdr']);
+const VALID_SEVERITIES = new Set(['low', 'medium', 'high', 'critical']);
+
+function findRunById(id: string): FuzzingRun | undefined {
+  return buildMockRuns().find((r) => r.id === id);
+}
+
+const runAssertions = () => {
+  // known run exists
+  const run = findRunById('run-1000');
+  assert.ok(run !== undefined, 'run-1000 should be present in mock data');
+  assert.equal(run.id, 'run-1000');
+  assert.ok(VALID_STATUSES.has(run.status), `unexpected status: ${run.status}`);
+  assert.ok(VALID_AREAS.has(run.area), `unexpected area: ${run.area}`);
+  assert.ok(VALID_SEVERITIES.has(run.severity), `unexpected severity: ${run.severity}`);
+  assert.equal(typeof run.duration, 'number');
+  assert.equal(typeof run.seedCount, 'number');
+  assert.equal(typeof run.cpuInstructions, 'number');
+  assert.equal(typeof run.memoryBytes, 'number');
+  assert.equal(typeof run.minResourceFee, 'number');
+
+  // another known run exists
+  const run2 = findRunById('run-1024');
+  assert.ok(run2 !== undefined, 'run-1024 should be present in mock data');
+
+  // missing run returns undefined (→ 404 in the handler)
+  const missing = findRunById('run-9999');
+  assert.equal(missing, undefined, 'non-existent run should return undefined');
+
+  // all runs satisfy the FuzzingRun shape requirements
+  const all = buildMockRuns();
+  assert.ok(all.length > 0, 'mock dataset must be non-empty');
+  for (const r of all) {
+    assert.equal(typeof r.id, 'string');
+    assert.ok(VALID_STATUSES.has(r.status));
+    assert.ok(VALID_AREAS.has(r.area));
+    assert.ok(VALID_SEVERITIES.has(r.severity));
+    assert.equal(typeof r.cpuInstructions, 'number');
+    assert.equal(typeof r.memoryBytes, 'number');
+    assert.equal(typeof r.minResourceFee, 'number');
+    assert.ok(r.crashDetail === null || typeof r.crashDetail === 'object');
+  }
+
+  // failed runs carry a crashDetail payload
+  const failedRuns = all.filter((r) => r.status === 'failed');
+  assert.ok(failedRuns.length > 0, 'mock dataset must contain at least one failed run');
+  for (const r of failedRuns) {
+    assert.ok(r.crashDetail !== null, `failed run ${r.id} must have crashDetail`);
+    assert.equal(typeof r.crashDetail!.signature, 'string');
+    assert.equal(typeof r.crashDetail!.replayAction, 'string');
+  }
+};
+
+runAssertions();
+console.log('get-run-by-id.test.ts: all assertions passed');


### PR DESCRIPTION
## Summary

- Adds `apps/web/src/app/api/runs/[id]/route.ts` — Next.js route handler for `GET /api/runs/[id]`
- When `RUNS_API_URL` is set, the request is forwarded to the Rust fuzzer backend; otherwise the in-process mock dataset serves the response so the frontend works standalone
- Adds focused test `apps/web/src/app/api/runs/get-run-by-id.test.ts` verifying the run-lookup contract and data shape

## Env vars

| Variable | Description |
|---|---|
| `RUNS_API_URL` | Base URL of the Rust fuzzer API, e.g. `http://localhost:8080`. Optional — omit to use mock data. |

## Test plan

- [ ] `./node_modules/.bin/tsc src/app/api/runs/get-run-by-id.test.ts src/app/mockRuns.ts src/app/types.ts --module commonjs --target es2020 --outDir build/test-tmp --esModuleInterop && node build/test-tmp/app/api/runs/get-run-by-id.test.js` — should print "all assertions passed"
- [ ] Existing `npm test` suite passes unchanged
- [ ] `GET /api/runs/run-1000` returns 200 with run JSON when dev server is running
- [ ] `GET /api/runs/run-9999` returns 404

Closes #617
Closes #618
Closes #619
Closes #620