### PR TITLE
feat: wire frontend pages to GET /api/runs and GET /api/runs/[id]

### DIFF
--- a/apps/web/src/app/api/runs/[id]/route.ts
+++ b/apps/web/src/app/api/runs/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { buildMockRuns } from '@/app/mockRuns';
+
+export async function GET(
+    _request: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    const run = buildMockRuns().find((r) => r.id === id);
+    if (!run) {
+        return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+    }
+    return NextResponse.json(run);
+}

--- a/apps/web/src/app/api/runs/route.ts
+++ b/apps/web/src/app/api/runs/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { buildMockRuns } from '@/app/mockRuns';
+
+export async function GET() {
+    const runs = buildMockRuns();
+    return NextResponse.json({ runs, total: runs.length });
+}

--- a/apps/web/src/app/api/runs/runs-api.test.ts
+++ b/apps/web/src/app/api/runs/runs-api.test.ts
@@ -1,0 +1,38 @@
+import * as assert from 'node:assert/strict';
+import { buildMockRuns } from '../../mockRuns';
+
+// Verify the data source used by the API routes returns a valid run list.
+
+const runs = buildMockRuns();
+
+// Sanity: runs list is non-empty
+assert.ok(runs.length > 0, 'buildMockRuns returns at least one run');
+
+// Every run has the required fields
+for (const run of runs) {
+    assert.ok(typeof run.id === 'string' && run.id.length > 0, `run.id must be a non-empty string (got ${run.id})`);
+    assert.ok(['running', 'completed', 'failed', 'cancelled'].includes(run.status), `run.status must be a valid RunStatus (got ${run.status})`);
+    assert.ok(['auth', 'state', 'budget', 'xdr'].includes(run.area), `run.area must be a valid RunArea (got ${run.area})`);
+    assert.ok(['low', 'medium', 'high', 'critical'].includes(run.severity), `run.severity must be a valid RunSeverity (got ${run.severity})`);
+    assert.ok(typeof run.duration === 'number', 'run.duration must be a number');
+    assert.ok(typeof run.seedCount === 'number', 'run.seedCount must be a number');
+    assert.ok(typeof run.cpuInstructions === 'number', 'run.cpuInstructions must be a number');
+    assert.ok(typeof run.memoryBytes === 'number', 'run.memoryBytes must be a number');
+    assert.ok(typeof run.minResourceFee === 'number', 'run.minResourceFee must be a number');
+}
+
+// GET /api/runs/[id] – lookup by id resolves correctly
+const first = runs[0];
+const found = runs.find((r) => r.id === first.id);
+assert.deepEqual(found, first, 'lookup by id returns the correct run');
+
+// GET /api/runs/[id] – missing id resolves to undefined (API returns 404)
+const missing = runs.find((r) => r.id === 'does-not-exist');
+assert.strictEqual(missing, undefined, 'lookup of unknown id returns undefined');
+
+// All run ids are unique
+const ids = runs.map((r) => r.id);
+const uniqueIds = new Set(ids);
+assert.strictEqual(uniqueIds.size, ids.length, 'all run ids are unique');
+
+console.log('runs-api.test.ts: all assertions passed');

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -67,7 +67,6 @@ import ContributorSLATargets from "./ContributorSLATargets";
 import { CampaignConfig } from "./types";
 import { ResourceFeeInsightPanel } from "./implement-resource-fee-insight-panel-component";
 import AdvancedDashboardFilters, { DashboardFilters } from "./create-advanced-dashboard-filters-page";
-import { buildMockRuns } from "./mockRuns";
 
 const ITEMS_PER_PAGE = 10;
 const CPU_WARNING = 900_000;
@@ -146,8 +145,6 @@ function HomeContent() {
     searchTerm: '',
   });
 
-  // Check if demo loading mode is enabled via query flag
-  const demoLoading = searchParams.get("demoLoading") === "1";
 
   const handleToggleRunSelection = useCallback((runId: string) => {
     setSelectedRunIds(prev => {
@@ -365,26 +362,16 @@ function HomeContent() {
   // non-urgent update, which avoids the react-hooks/set-state-in-effect lint rule.
   useEffect(() => {
     let cancelled = false;
-    // Mark the loading reset as a low-priority transition so React batches it
-    // together with any concurrent work, avoiding a synchronous setState in effect.
     const ctrl = new AbortController();
     const resetAndFetch = async () => {
       setDataState("loading");
       setRuns([]);
       try {
-        // Simulate a network round-trip (800ms)
-        await new Promise<void>((resolve, reject) => {
-          const t = window.setTimeout(() => {
-            if (ctrl.signal.aborted) return;
-            // Only simulate failure when demoLoading flag is present
-            if (demoLoading && Math.random() < 0.1)
-              reject(new Error("Simulated network error"));
-            else resolve();
-          }, 800);
-          ctrl.signal.addEventListener("abort", () => window.clearTimeout(t));
-        });
+        const res = await fetch('/api/runs', { signal: ctrl.signal });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
         if (!cancelled) {
-          setRuns(buildMockRuns());
+          setRuns(data.runs);
           setDataState("success");
         }
       } catch {
@@ -400,7 +387,7 @@ function HomeContent() {
       ctrl.abort();
       window.clearTimeout(t);
     };
-  }, [fetchAttempt, demoLoading]);
+  }, [fetchAttempt]);
 
   useEffect(() => {
     if (selectedRunId && !selectedRun) {

--- a/apps/web/src/app/runs/[id]/page.tsx
+++ b/apps/web/src/app/runs/[id]/page.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import type { LedgerStateChange } from '../../types';
-import { buildMockRuns } from '../../mockRuns';
+import type { FuzzingRun, LedgerStateChange } from '../../types';
 import RunIssueLinkPage53 from '../../add-run-issue-link-page-53';
 import RunStatusTimeline from '../../RunStatusTimeline';
 import DownloadArtifactsButton from './DownloadArtifactsButton';
@@ -41,9 +40,17 @@ const changeBadge = {
 const formatBytes = (bytes: number): string => `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 const formatDate = (value?: string): string => (value ? new Date(value).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short', timeZone: 'UTC' }) : 'Pending');
 
+async function fetchRun(id: string): Promise<FuzzingRun | null> {
+    const base = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+    const res = await fetch(`${base}/api/runs/${encodeURIComponent(id)}`, { cache: 'no-store' });
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`Failed to fetch run ${id}`);
+    return res.json() as Promise<FuzzingRun>;
+}
+
 export default async function RunDetailPage({ params }: RunDetailPageProps) {
     const { id } = await params;
-    const run = buildMockRuns().find((entry) => entry.id === id);
+    const run = await fetchRun(id);
 
     if (!run) {
         notFound();

--- a/apps/web/src/app/trends/page.tsx
+++ b/apps/web/src/app/trends/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { RunArea, RunSeverity, FuzzingRun } from '../types';
+import { FuzzingRun, RunArea, RunSeverity } from '../types';
 import { FilterBar } from './FilterBar';
 import { CrashTrendChart } from './CrashTrendChart';
 import {
@@ -18,12 +18,18 @@ import {
  *
  * Visualizes crash signature frequency over time with interactive
  * filtering by area, severity, and specific signatures.
- *
- * TODO: Integrate with real API to fetch FuzzingRun data instead of using mock data.
  */
 export default function CrashTrendPage() {
-  // TODO: Replace with real data source (API call, context, etc.)
-  const runs = useMockFuzzingRuns();
+  const [runs, setRuns] = useState<FuzzingRun[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/runs')
+      .then((res) => res.json())
+      .then((data) => { if (!cancelled) setRuns(data.runs); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
 
   // Filter state
   const [selectedAreas, setSelectedAreas] = useState<RunArea[]>([]);
@@ -207,55 +213,3 @@ function calculateTotalCrashes(chartData: Record<string, string | number>[]): nu
   return total;
 }
 
-/**
- * Generate mock FuzzingRun data for demo/testing.
- * TODO: Replace with real API call after integration.
- */
-function useMockFuzzingRuns(): FuzzingRun[] {
-  // In a real implementation, this would fetch from an API or receive via props.
-  // For now, we generate realistic mock data for testing the visualization.
-
-  const areas: RunArea[] = ['auth', 'state', 'budget', 'xdr'];
-  const severities: RunSeverity[] = ['low', 'medium', 'high', 'critical'];
-  const baseDate = new Date('2026-03-20');
-
-  const runs: FuzzingRun[] = [];
-  let runId = 1;
-
-  // Generate 50 mock crashes across the past 10 days
-  for (let dayOffset = 0; dayOffset < 10; dayOffset++) {
-    const date = new Date(baseDate);
-    date.setDate(date.getDate() - dayOffset);
-
-    const crashCount = Math.floor(Math.random() * 8) + 1;
-
-    for (let i = 0; i < crashCount; i++) {
-      const area = areas[Math.floor(Math.random() * areas.length)];
-      const severity = severities[Math.floor(Math.random() * severities.length)];
-
-      // Generate stable signature hashes (in real data, these are FNV-1a hashes)
-      const signature = `0x${(Math.random() * 0xffffffff | 0).toString(16).padStart(8, '0')}`;
-
-      runs.push({
-        id: `run-${runId++}`,
-        status: 'failed',
-        area,
-        severity,
-        duration: Math.floor(Math.random() * 60000) + 1000,
-        seedCount: Math.floor(Math.random() * 1000) + 10,
-        cpuInstructions: Math.floor(Math.random() * 1000000),
-        memoryBytes: Math.floor(Math.random() * 10000000),
-        minResourceFee: Math.floor(Math.random() * 100000),
-        finishedAt: date.toISOString(),
-        crashDetail: {
-          failureCategory: area.toUpperCase(),
-          signature,
-          payload: `{"type":"${area}","test":true}`,
-          replayAction: `crashlab replay --signature ${signature}`,
-        },
-      });
-    }
-  }
-
-  return runs;
-}

--- a/apps/web/src/app/triage/page.tsx
+++ b/apps/web/src/app/triage/page.tsx
@@ -9,39 +9,18 @@
  */
 
 import { useEffect, useState } from "react";
-import type { FuzzingRun, RunStatus, RunArea, RunSeverity } from "../types";
+import type { FuzzingRun } from "../types";
 import {
   TRIAGE_COLUMNS,
   getColumnRuns,
   type TriageColumnDef,
 } from "./triage-board-utils";
 
-const MOCK_RUNS: FuzzingRun[] = Array.from({ length: 18 }, (_, i) => ({
-  id: `run-${1000 + i}`,
-  status: (["failed", "running", "cancelled", "completed"] as RunStatus[])[
-    i % 4
-  ],
-  area: (["auth", "state", "budget", "xdr"] as RunArea[])[i % 4],
-  severity: (["low", "medium", "high", "critical"] as RunSeverity[])[i % 4],
-  duration: 120_000 + i * 30_000,
-  seedCount: 10_000 + i * 1_000,
-  cpuInstructions: 400_000 + i * 10_000,
-  memoryBytes: 1_500_000 + i * 100_000,
-  minResourceFee: 500 + i * 50,
-  crashDetail:
-    i % 4 === 0
-      ? {
-          failureCategory: "InvariantViolation",
-          signature: `sig:${1000 + i}`,
-          payload: "{}",
-          replayAction: `cargo run --bin replay-single-seed -- bundle-${i}.json`,
-        }
-      : null,
-}));
-
 async function fetchRuns(): Promise<FuzzingRun[]> {
-  await new Promise((r) => setTimeout(r, 700));
-  return MOCK_RUNS;
+  const res = await fetch('/api/runs');
+  if (!res.ok) throw new Error('Failed to fetch runs');
+  const data = await res.json();
+  return data.runs as FuzzingRun[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #621, #622, #623, #624 (ROADMAP-034 to ROADMAP-037)

- Add GET /api/runs route returning all runs via buildMockRuns()
- Add GET /api/runs/[id] route returning a single run (404 on miss)
- Replace home page buildMockRuns() call with fetch('/api/runs')
- Replace triage page MOCK_RUNS + fake delay with fetch('/api/runs')
- Replace trends page useMockFuzzingRuns() with useEffect + fetch('/api/runs')
- Wire run detail server component to GET /api/runs/[id] via NEXT_PUBLIC_APP_URL
- Add runs-api.test.ts validating data shape and id uniqueness

Closes #621 
Closes #622 
Closes #623 
Closes #624 

Env var: NEXT_PUBLIC_APP_URL — set to deployment origin (e.g. https://yourapp.vercel.app). Falls back to http://localhost:3000 for local development.

## Summary

<!-- What does this PR do? Link ROADMAP-XXX or GitHub issue -->

Closes #

## Checklist

- [ ] Branch name follows `issue/<number>-<slug>`
- [ ] Scope limited to files listed in the issue
- [ ] Tests added or updated
- [ ] `pnpm-lock.yaml` / `package-lock.json` **not** modified
- [ ] If `package.json` changed: maintainer approval requested below

## Maintainer approval (package.json only)

<!-- Delete this section if package.json unchanged -->

- [ ] Required dependency change explained:

## Test plan

<!-- Steps to verify -->
