### PR TITLE
feat(cli): add crashlab runs list subcommand (ROADMAP-029)

### DIFF
--- a/contracts/crashlab-core/src/bin/crashlab.rs
+++ b/contracts/crashlab-core/src/bin/crashlab.rs
@@ -6,8 +6,9 @@
 //! to run all regression fixtures from a file or directory.
 
 use crashlab_core::{
-    RunId, cancel_marker_path, default_state_dir, replay_mismatch_message, replay_seed_bundle_path,
-    replay_success_message, request_cancel_run, run_regression_suite_from_json,
+    RunId, cancel_marker_path, cancel_requested, default_state_dir, replay_mismatch_message,
+    replay_seed_bundle_path, replay_success_message, request_cancel_run,
+    run_regression_suite_from_json,
 };
 use std::fs;
 use std::path::Path;
@@ -74,6 +75,13 @@ fn main() {
             }
             run_regression_suite_command(path);
         }
+        (Some("runs"), Some("list"), None, None) => {
+            if args.next().is_some() {
+                print_usage();
+                std::process::exit(1);
+            }
+            list_runs();
+        }
         _ => {
             print_usage();
             std::process::exit(1);
@@ -84,9 +92,44 @@ fn main() {
 fn print_usage() {
     eprintln!(
         "usage: crashlab run cancel <id>\n\
+                crashlab runs list\n\
                 crashlab replay seed <bundle-json-path>\n\
                 crashlab regression-suite <suite-json-path-or-directory>"
     );
+}
+
+fn list_runs() {
+    let base = default_state_dir();
+    let runs_dir = base.join("runs");
+
+    let entries = match std::fs::read_dir(&runs_dir) {
+        Ok(e) => e,
+        Err(_) => {
+            println!("no runs found");
+            return;
+        }
+    };
+
+    let mut ids: Vec<u64> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.file_name().to_string_lossy().parse::<u64>().ok())
+        .collect();
+
+    if ids.is_empty() {
+        println!("no runs found");
+        return;
+    }
+
+    ids.sort_unstable();
+    for id in ids {
+        let run_id = RunId(id);
+        let status = if cancel_requested(run_id, &base) {
+            "cancelled"
+        } else {
+            "active"
+        };
+        println!("{id}\t{status}");
+    }
 }
 
 fn run_regression_suite_command(path: &str) {

--- a/contracts/crashlab-core/tests/runs_list_cli.rs
+++ b/contracts/crashlab-core/tests/runs_list_cli.rs
@@ -1,0 +1,98 @@
+use crashlab_core::{RunId, request_cancel_run};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_tmp() -> PathBuf {
+    let n = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("crashlab-runs-list-{n}"))
+}
+
+#[test]
+fn runs_list_empty_state_dir_prints_no_runs() {
+    let base = unique_tmp();
+    fs::create_dir_all(&base).expect("create base dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_crashlab"))
+        .env("CRASHLAB_STATE_DIR", &base)
+        .args(["runs", "list"])
+        .output()
+        .expect("run crashlab binary");
+
+    assert!(output.status.success(), "expected success");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("no runs found"), "unexpected stdout: {stdout}");
+
+    let _ = fs::remove_dir_all(&base);
+}
+
+#[test]
+fn runs_list_shows_active_run() {
+    let base = unique_tmp();
+    // Create a run directory without a cancel marker.
+    let run_dir = base.join("runs").join("7");
+    fs::create_dir_all(&run_dir).expect("create run dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_crashlab"))
+        .env("CRASHLAB_STATE_DIR", &base)
+        .args(["runs", "list"])
+        .output()
+        .expect("run crashlab binary");
+
+    assert!(output.status.success(), "expected success");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("7"), "expected run id 7 in output: {stdout}");
+    assert!(stdout.contains("active"), "expected 'active' status: {stdout}");
+
+    let _ = fs::remove_dir_all(&base);
+}
+
+#[test]
+fn runs_list_shows_cancelled_run() {
+    let base = unique_tmp();
+    request_cancel_run(RunId(3), &base).expect("request cancel");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_crashlab"))
+        .env("CRASHLAB_STATE_DIR", &base)
+        .args(["runs", "list"])
+        .output()
+        .expect("run crashlab binary");
+
+    assert!(output.status.success(), "expected success");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("3"), "expected run id 3 in output: {stdout}");
+    assert!(stdout.contains("cancelled"), "expected 'cancelled' status: {stdout}");
+
+    let _ = fs::remove_dir_all(&base);
+}
+
+#[test]
+fn runs_list_sorts_ids_ascending() {
+    let base = unique_tmp();
+    for id in [10u64, 2, 5] {
+        fs::create_dir_all(base.join("runs").join(id.to_string())).expect("create run dir");
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_crashlab"))
+        .env("CRASHLAB_STATE_DIR", &base)
+        .args(["runs", "list"])
+        .output()
+        .expect("run crashlab binary");
+
+    assert!(output.status.success(), "expected success");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let positions: Vec<usize> = ["2", "5", "10"]
+        .iter()
+        .map(|id| stdout.find(id).expect("id not found"))
+        .collect();
+    assert!(
+        positions.windows(2).all(|w| w[0] < w[1]),
+        "expected ascending order: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&base);
+}


### PR DESCRIPTION
Closes #616 
- Add `crashlab runs list` to scan state dir and print run IDs with active/cancelled status, sorted ascending by ID
- Import cancel_requested in crashlab.rs
- Update print_usage to document the new subcommand
- Add integration tests in tests/runs_list_cli.rs covering empty dir, active run, cancelled run, and ascending sort order

## Summary

<!-- What does this PR do? Link ROADMAP-XXX or GitHub issue -->

Closes #

## Checklist

- [ ] Branch name follows `issue/<number>-<slug>`
- [ ] Scope limited to files listed in the issue
- [ ] Tests added or updated
- [ ] `pnpm-lock.yaml` / `package-lock.json` **not** modified
- [ ] If `package.json` changed: maintainer approval requested below

## Maintainer approval (package.json only)

<!-- Delete this section if package.json unchanged -->

- [ ] Required dependency change explained:

## Test plan

<!-- Steps to verify -->
