### PR TITLE
feat(runs): add export JSON/CSV toolbar actions and annotations/tags API routes (ROADMAP-074/075/076/077)

### DIFF
--- a/apps/web/src/app/api/runs/[id]/annotations/route.ts
+++ b/apps/web/src/app/api/runs/[id]/annotations/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildMockRuns } from '@/app/mockRuns';
+
+// In-memory store keyed by run ID (persists for the lifetime of the process)
+const annotationStore = new Map<string, string[]>();
+
+function getAnnotations(id: string): string[] {
+  if (annotationStore.has(id)) {
+    return annotationStore.get(id)!;
+  }
+  // Seed from mock data on first access
+  const run = buildMockRuns().find((r) => r.id === id);
+  const initial = run?.annotations ?? [];
+  annotationStore.set(id, [...initial]);
+  return annotationStore.get(id)!;
+}
+
+/**
+ * GET /api/runs/[id]/annotations
+ * Returns the current annotation list for a run.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const run = buildMockRuns().find((r) => r.id === id);
+  if (!run) {
+    return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+  }
+  return NextResponse.json({ runId: id, annotations: getAnnotations(id) });
+}
+
+/**
+ * POST /api/runs/[id]/annotations
+ * Appends a new annotation. Body: { text: string }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const run = buildMockRuns().find((r) => r.id === id);
+  if (!run) {
+    return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const text = (body as Record<string, unknown>)?.text;
+  if (typeof text !== 'string' || !text.trim()) {
+    return NextResponse.json({ error: 'text is required and must be a non-empty string' }, { status: 400 });
+  }
+  if (text.trim().length > 500) {
+    return NextResponse.json({ error: 'Annotation exceeds 500 character limit' }, { status: 400 });
+  }
+
+  const annotations = getAnnotations(id);
+  annotations.push(text.trim());
+  return NextResponse.json({ runId: id, annotations }, { status: 201 });
+}
+
+/**
+ * DELETE /api/runs/[id]/annotations
+ * Removes an annotation by index. Body: { index: number }
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const run = buildMockRuns().find((r) => r.id === id);
+  if (!run) {
+    return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const index = (body as Record<string, unknown>)?.index;
+  if (typeof index !== 'number' || !Number.isInteger(index)) {
+    return NextResponse.json({ error: 'index must be an integer' }, { status: 400 });
+  }
+
+  const annotations = getAnnotations(id);
+  if (index < 0 || index >= annotations.length) {
+    return NextResponse.json({ error: 'Index out of range' }, { status: 400 });
+  }
+
+  annotations.splice(index, 1);
+  return NextResponse.json({ runId: id, annotations });
+}

--- a/apps/web/src/app/api/runs/[id]/tags/route.ts
+++ b/apps/web/src/app/api/runs/[id]/tags/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildMockRuns } from '@/app/mockRuns';
+
+// In-memory store keyed by run ID (persists for the lifetime of the process)
+const tagStore = new Map<string, string[]>();
+
+function normTag(tag: string): string {
+  return tag.trim().toLowerCase().replace(/\s+/g, '-');
+}
+
+function getTags(id: string): string[] {
+  if (!tagStore.has(id)) {
+    tagStore.set(id, []);
+  }
+  return tagStore.get(id)!;
+}
+
+/**
+ * GET /api/runs/[id]/tags
+ * Returns the current tag list for a run.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const run = buildMockRuns().find((r) => r.id === id);
+  if (!run) {
+    return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+  }
+  return NextResponse.json({ runId: id, tags: getTags(id) });
+}
+
+/**
+ * POST /api/runs/[id]/tags
+ * Adds a tag (normalized to kebab-case). Body: { tag: string }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const run = buildMockRuns().find((r) => r.id === id);
+  if (!run) {
+    return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const raw = (body as Record<string, unknown>)?.tag;
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return NextResponse.json({ error: 'tag is required and must be a non-empty string' }, { status: 400 });
+  }
+
+  const tag = normTag(raw);
+  if (tag.length > 64) {
+    return NextResponse.json({ error: 'Tag exceeds 64 character limit' }, { status: 400 });
+  }
+
+  const tags = getTags(id);
+  if (!tags.includes(tag)) {
+    tags.push(tag);
+    tags.sort();
+  }
+  return NextResponse.json({ runId: id, tags }, { status: 201 });
+}
+
+/**
+ * DELETE /api/runs/[id]/tags
+ * Removes a tag by value. Body: { tag: string }
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const run = buildMockRuns().find((r) => r.id === id);
+  if (!run) {
+    return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const raw = (body as Record<string, unknown>)?.tag;
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return NextResponse.json({ error: 'tag is required' }, { status: 400 });
+  }
+
+  const tag = normTag(raw);
+  const tags = getTags(id);
+  const idx = tags.indexOf(tag);
+  if (idx === -1) {
+    return NextResponse.json({ error: 'Tag not found' }, { status: 404 });
+  }
+
+  tags.splice(idx, 1);
+  return NextResponse.json({ runId: id, tags });
+}


### PR DESCRIPTION


## Summary

Implements four product UI revamp tasks for the `/runs` toolbar and run detail API layer.

---

## Changes

### ROADMAP-074 — Export JSON from /runs toolbar
**File:** `apps/web/src/app/add-export-run-json.tsx`

Toolbar button that serializes the current `FuzzingRun[]` array to pretty-printed JSON and triggers a browser download (`soroban-runs-export-<date>.json`). Includes a loading spinner during the async blob creation and shows the total record count. Matches existing Tailwind blue-accent card pattern.

---

### ROADMAP-075 — Export CSV from /runs toolbar
**File:** `apps/web/src/app/add-export-run-csv.tsx`

Toolbar button that converts runs to UTF-8 CSV (headers + one row per run) and triggers a browser download (`soroban-runs-export-<date>.csv`). Columns: ID, Status, Area, Severity, Duration, Seed Count, CPU Instructions, Memory, Min Fee. Matches existing Tailwind emerald-accent card pattern.

---

### ROADMAP-076 — Persist annotations via API
**File:** `apps/web/src/app/api/runs/[id]/annotations/route.ts`

New Next.js route handler at `/api/runs/[id]/annotations`:
- `GET` — returns current annotation list (seeded from mock data on first access)
- `POST` — appends a new annotation (`{ text: string }`, max 500 chars)
- `DELETE` — removes annotation by index (`{ index: number }`)

---

### ROADMAP-077 — Persist tags via API
**File:** `apps/web/src/app/api/runs/[id]/tags/route.ts`

New Next.js route handler at `/api/runs/[id]/tags`:
- `GET` — returns current tag list for a run
- `POST` — adds a tag (`{ tag: string }`, normalized to kebab-case, max 64 chars, deduped)
- `DELETE` — removes a tag by value (`{ tag: string }`)

---

## Checklist

- [x] No new mock data paths introduced
- [x] Matches existing Tailwind patterns
- [x] No changes to `pnpm-lock.yaml` or `package-lock.json`
- [x] No changes to `package.json`
- [x] Scope limited to files listed per issue

Closes #661
Closes #662
Closes #663
Closes #664

