### PR TITLE
[frontend] Optional notifications feed API

### DIFF
--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+interface NotificationFeedItem {
+  id: string;
+  title: string;
+  message: string;
+  severity: 'info' | 'success' | 'warning' | 'error';
+  createdAt: string;
+  read: boolean;
+}
+
+interface NotificationFeedResponse {
+  notifications: NotificationFeedItem[];
+  total: number;
+  optional: true;
+}
+
+function buildEmptyFeed(): NotificationFeedResponse {
+  return {
+    notifications: [],
+    total: 0,
+    optional: true,
+  };
+}
+
+async function fetchNotificationsFeed(request: NextRequest, feedUrl: string): Promise<NotificationFeedResponse> {
+  const target = new URL(feedUrl, request.nextUrl.origin);
+  for (const [key, value] of request.nextUrl.searchParams.entries()) {
+    target.searchParams.set(key, value);
+  }
+
+  const response = await fetch(target.toString(), {
+    headers: {
+      Accept: 'application/json',
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    return buildEmptyFeed();
+  }
+
+  const payload = (await response.json()) as Partial<NotificationFeedResponse> & {
+    notifications?: NotificationFeedItem[];
+  };
+
+  if (!Array.isArray(payload.notifications)) {
+    return buildEmptyFeed();
+  }
+
+  return {
+    notifications: payload.notifications,
+    total: typeof payload.total === 'number' ? payload.total : payload.notifications.length,
+    optional: true,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const feedUrl = process.env.NOTIFICATIONS_FEED_URL ?? process.env.NOTIFICATIONS_API_URL;
+
+  if (!feedUrl) {
+    return NextResponse.json(buildEmptyFeed());
+  }
+
+  try {
+    return NextResponse.json(await fetchNotificationsFeed(request, feedUrl));
+  } catch (error) {
+    console.error('GET /api/notifications failed:', error);
+    return NextResponse.json(buildEmptyFeed());
+  }
+}


### PR DESCRIPTION
## Summary\n- add GET /api/notifications route handler for optional external notification feeds\n- return an empty optional feed when no external feed URL is configured\n- fail soft to empty feed when upstream fetch fails or returns non-OK\n\n## Testing\n- npm run build (fails in unrelated pre-existing files)\n- npm test (fails due existing script path mismatch in repository)\n\n
Closes #665