### PR TITLE
[frontend] Implement MetricsExportDependencies adapter

### DIFF
--- a/apps/web/src/app/integrate-metrics-export-to-prometheus-utils.test.ts
+++ b/apps/web/src/app/integrate-metrics-export-to-prometheus-utils.test.ts
@@ -7,6 +7,7 @@ import {
   ExportConfig,
   MetricsExportDependencies,
 } from './integrate-metrics-export-to-prometheus-utils';
+import { createPrometheusMetricsExportDependencies } from '../lib/integrations/prometheus-adapter';
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(`Assertion failed: ${message}`);
@@ -137,6 +138,44 @@ async function testRunMetricsExportIntegrationFlow_healthFailure(): Promise<void
   console.log('✓ testRunMetricsExportIntegrationFlow_healthFailure passed');
 }
 
+async function testCreatePrometheusMetricsExportDependencies(): Promise<void> {
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const deps = createPrometheusMetricsExportDependencies({
+    endpoint: 'https://prometheus.internal.crashlab.io/metrics',
+    interval: 30,
+    labels: { env: 'production' },
+    fetchImpl: async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      requests.push({ url, init });
+
+      if ((init?.method ?? 'GET') === 'POST') {
+        return new Response(JSON.stringify({ pushedSeries: 6 }), {
+          status: 202,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    },
+  });
+
+  const config = await deps.resolveConfig();
+  assert(config !== null, 'adapter should resolve a config when enabled');
+  assert(config?.endpoint === 'https://prometheus.internal.crashlab.io/metrics', 'adapter should normalize endpoint');
+
+  const push = await deps.pushMetrics(config!);
+  assert(push.accepted, 'adapter should accept successful push responses');
+  assert(push.pushedSeries === 6, 'adapter should surface pushed series count');
+
+  const health = await deps.queryExporterHealth(config!.endpoint);
+  assert(health.healthy, 'adapter should mark healthy endpoints as healthy');
+  assert(health.statusCode === 200, 'adapter should surface health status code');
+  assert(requests.length === 2, 'adapter should perform push and health requests');
+  assert(requests[0].init?.method === 'POST', 'first request should push metrics');
+  assert(requests[1].init?.method === 'GET', 'second request should query health');
+  console.log('✓ testCreatePrometheusMetricsExportDependencies passed');
+}
+
 async function runAllTests(): Promise<void> {
   console.log('Running Metrics Export to Prometheus Utils Tests...\\n');
   try {
@@ -151,6 +190,7 @@ async function runAllTests(): Promise<void> {
     await testRunMetricsExportIntegrationFlow_configUnavailable();
     await testRunMetricsExportIntegrationFlow_edgePushRejected();
     await testRunMetricsExportIntegrationFlow_healthFailure();
+    await testCreatePrometheusMetricsExportDependencies();
     console.log('\\n✅ All Metrics Export to Prometheus utils tests passed!');
   } catch (error) {
     console.error('\\n❌ Test failed:', error);

--- a/apps/web/src/lib/integrations/prometheus-adapter.ts
+++ b/apps/web/src/lib/integrations/prometheus-adapter.ts
@@ -1,0 +1,104 @@
+import {
+  type ExportConfig,
+  type MetricsExportDependencies,
+} from '../../app/integrate-metrics-export-to-prometheus-utils';
+
+export interface PrometheusAdapterOptions {
+  endpoint: string;
+  interval?: number;
+  enabled?: boolean;
+  labels?: Record<string, string>;
+  pushPath?: string;
+  healthPath?: string;
+  fetchImpl?: typeof fetch;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function joinUrl(base: string, path?: string): string {
+  if (!path) {
+    return base;
+  }
+
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+
+  return `${trimTrailingSlash(base)}${path.startsWith('/') ? '' : '/'}${path}`;
+}
+
+function toExportConfig(options: PrometheusAdapterOptions): ExportConfig {
+  return {
+    endpoint: trimTrailingSlash(options.endpoint),
+    interval: options.interval ?? 15,
+    enabled: options.enabled ?? true,
+    labels: options.labels ?? {},
+  };
+}
+
+async function parsePushedSeries(response: Response): Promise<number> {
+  try {
+    const payload = (await response.json()) as { pushedSeries?: number; series?: number };
+    if (typeof payload.pushedSeries === 'number') {
+      return payload.pushedSeries;
+    }
+
+    if (typeof payload.series === 'number') {
+      return payload.series;
+    }
+  } catch {
+    // Fall back to the response status below.
+  }
+
+  return response.ok ? 1 : 0;
+}
+
+export function createPrometheusMetricsExportDependencies(
+  options: PrometheusAdapterOptions,
+): MetricsExportDependencies {
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  return {
+    async resolveConfig() {
+      const config = toExportConfig(options);
+      return config.enabled ? config : null;
+    },
+
+    async pushMetrics(config) {
+      const response = await fetchImpl(joinUrl(config.endpoint, options.pushPath), {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          endpoint: config.endpoint,
+          interval: config.interval,
+          enabled: config.enabled,
+          labels: config.labels,
+        }),
+      });
+
+      return {
+        accepted: response.ok,
+        pushedSeries: await parsePushedSeries(response),
+      };
+    },
+
+    async queryExporterHealth(endpoint) {
+      const response = await fetchImpl(joinUrl(endpoint, options.healthPath), {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+        },
+      });
+
+      return {
+        healthy: response.ok,
+        statusCode: response.status,
+      };
+    },
+  };
+}


### PR DESCRIPTION
Closes #668

## Summary\n- add Prometheus adapter implementing MetricsExportDependencies\n- include URL normalization, push endpoint join, and health query helpers\n- extend metrics integration tests to validate adapter request/response flow\n\n## Testing\n- npm run build (fails in unrelated pre-existing files)\n- npm test (fails due existing script path mismatch in repository)\n\n

