### PR TITLE
feat(frontend): wire Prometheus UI + add issue-link adapters ROADMAP…

### DIFF
--- a/apps/web/src/app/integrate-metrics-export-to-prometheus.tsx
+++ b/apps/web/src/app/integrate-metrics-export-to-prometheus.tsx
@@ -22,7 +22,9 @@ import {
   MetricPoint,
   ExportConfig,
   generateInitialData,
-  analyzeTrend
+  analyzeTrend,
+  runMetricsExportIntegrationFlow,
+  MetricsExportDependencies
 } from './integrate-metrics-export-to-prometheus-utils';
 
 const DEFAULT_CONFIG: ExportConfig = {
@@ -89,7 +91,11 @@ export default function MetricsExportToPrometheus() {
   useEffect(() => {
     if (!config.enabled) return;
 
-    const interval = setInterval(() => {
+    // Use configured interval for polling (seconds). This replaces a hardcoded mock timer.
+    let cancelled = false;
+
+    const tick = async () => {
+      if (cancelled) return;
       setLatencyData(prev => {
         const newData = [...prev.slice(1), {
           time: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
@@ -97,21 +103,56 @@ export default function MetricsExportToPrometheus() {
         }];
         return newData;
       });
-    }, 3000);
+      // schedule next tick according to configured interval
+      setTimeout(tick, config.interval * 1000);
+    };
 
-    return () => clearInterval(interval);
-  }, [config.enabled]);
+    // start polling
+    setTimeout(tick, config.interval * 1000);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [config.enabled, config.interval]);
 
   const handleTestConnection = async () => {
     setIsTesting(true);
     setTestResult(null);
-    await new Promise(r => setTimeout(r, 1500));
-    const success = Math.random() > 0.1;
-    setTestResult(success ? 'success' : 'error');
-    setIsTesting(false);
+    try {
+      const deps: MetricsExportDependencies = {
+        resolveConfig: async () => ({ ...config }),
+        pushMetrics: async (cfg) => {
+          try {
+            const res = await fetch(cfg.endpoint, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ timestamp: Date.now(), labels: cfg.labels })
+            });
+            return { accepted: res.ok, pushedSeries: res.ok ? 1 : 0 };
+          } catch (e) {
+            return { accepted: false, pushedSeries: 0 };
+          }
+        },
+        queryExporterHealth: async (endpoint) => {
+          try {
+            // Try a lightweight GET to the endpoint to infer reachability
+            const res = await fetch(endpoint, { method: 'GET' });
+            return { healthy: res.ok, statusCode: res.status };
+          } catch (e) {
+            return { healthy: false, statusCode: 0 };
+          }
+        }
+      };
 
-    // Clear result after 3s
-    setTimeout(() => setTestResult(null), 3000);
+      const result = await runMetricsExportIntegrationFlow(deps);
+      setTestResult(result.success ? 'success' : 'error');
+    } catch (e) {
+      setTestResult('error');
+    } finally {
+      setIsTesting(false);
+      // Clear result after 3s
+      setTimeout(() => setTestResult(null), 3000);
+    }
   };
 
   const currentLatency = latencyData[latencyData.length - 1].value;

--- a/apps/web/src/lib/integrations/github-issues.ts
+++ b/apps/web/src/lib/integrations/github-issues.ts
@@ -1,0 +1,22 @@
+/**
+ * GitHub Issue Link Adapter (stub)
+ *
+ * Small, dependency-free helper that resolves a GitHub issue link for use
+ * in the UI. This is intentionally lightweight and works without a token.
+ */
+
+export interface ResolvedIssueLink {
+  url: string;
+  title?: string;
+}
+
+export async function resolveGithubIssueLink(owner: string, repo: string, issueNumber: number): Promise<ResolvedIssueLink> {
+  // Construct canonical GitHub issue URL. Consumers may later extend this to
+  // call the GitHub API for richer metadata.
+  return {
+    url: `https://github.com/${owner}/${repo}/issues/${issueNumber}`,
+    title: `#${issueNumber}`,
+  };
+}
+
+export default { resolveGithubIssueLink };

--- a/apps/web/src/lib/integrations/jira-issues.ts
+++ b/apps/web/src/lib/integrations/jira-issues.ts
@@ -1,0 +1,18 @@
+/**
+ * Jira Issue Link Adapter (stub)
+ *
+ * Builds a canonical issue link for Jira instances. This is a stub that
+ * can be extended to call Jira REST API when credentials are available.
+ */
+
+export interface ResolvedJiraLink {
+  url: string;
+  key: string;
+}
+
+export async function resolveJiraIssueLink(baseUrl: string, issueKey: string): Promise<ResolvedJiraLink> {
+  const base = baseUrl.replace(/\/$/, '');
+  return { url: `${base}/browse/${issueKey}`, key: issueKey };
+}
+
+export default { resolveJiraIssueLink };

--- a/apps/web/src/lib/integrations/linear-issues.ts
+++ b/apps/web/src/lib/integrations/linear-issues.ts
@@ -1,0 +1,17 @@
+/**
+ * Linear Issue Link Adapter (stub)
+ *
+ * Creates canonical links for Linear issues. This is a small helper used by
+ * UI components until a richer API-backed implementation is available.
+ */
+
+export interface ResolvedLinearLink {
+  url: string;
+  id: string;
+}
+
+export async function resolveLinearIssueLink(team: string, issueId: string): Promise<ResolvedLinearLink> {
+  return { url: `https://linear.app/${team}/issue/${issueId}`, id: issueId };
+}
+
+export default { resolveLinearIssueLink };


### PR DESCRIPTION
closes #669
closes #670 
closes #671 
closes #672


PR description 
- Summary
  - Wire the Prometheus metrics UI to a real integration flow and replace a hardcoded mock timer with polling that uses the configured interval (ROADMAP-082).
  - Add lightweight adapter stubs for GitHub, Jira, and Linear issue links for use by frontend components (ROADMAP-083 / ROADMAP-084 / ROADMAP-085).

- Files changed
  - integrate-metrics-export-to-prometheus.tsx — updated: wire to `runMetricsExportIntegrationFlow`, use configured polling interval, and call a fetch-based integration dependency for testing connection.
  - github-issues.ts — added: simple GitHub issue link adapter stub.
  - jira-issues.ts — added: simple Jira issue link adapter stub.
  - linear-issues.ts — added: simple Linear issue link adapter stub.

- What I changed (concise)
  - Replaced a fixed mock setInterval with polling driven by `config.interval`.
  - Implemented `handleTestConnection` to run `runMetricsExportIntegrationFlow` with a small, fetch-based `MetricsExportDependencies` implementation (resolveConfig / pushMetrics / queryExporterHealth).
  - Added three minimal adapters that produce canonical issue URLs (safe, no auth required). They can be extended later to call provider APIs when tokens/credentials are available.

- Manual test steps
  1. Start the frontend (project-specific dev command).
  2. Open the Prometheus Metrics Integration UI (the page using integrate-metrics-export-to-prometheus.tsx).
  3. Toggle the export `Resume/ Pause` control and observe the live status pulse.
  4. Click `Test Connection`. The UI will show a success or error state based on the integration flow run.
  5. Verify adapter stubs:
     - In a dev console or component, import and call:
       - `resolveGithubIssueLink('owner','repo',123)` → returns GitHub URL.
       - `resolveJiraIssueLink('https://jira.example.com','PROJ-123')` → returns Jira URL.
       - `resolveLinearIssueLink('team','ABC-123')` → returns Linear URL.

- Checklist
  - Manual test steps included above.
  - No lockfile (`pnpm-lock.json` / package-lock.json) changes.
  - No `package.json` changes were made.

