### PR TITLE
feat: remove mock fetch from alerting page and persist webhooks via API

### DIFF
--- a/apps/web/src/app/alerting-settings-utils.test.ts
+++ b/apps/web/src/app/alerting-settings-utils.test.ts
@@ -26,25 +26,47 @@ const runAssertions = (): void => {
   assert.equal(toggled[0].enabled, true);
   assert.equal(initialAlerts[0].enabled, false); // pure
 
+  // Test toggle unknown id returns unchanged list
+  const toggledUnknown = toggleAlert(initialAlerts, 'unknown-id');
+  assert.deepEqual(toggledUnknown, initialAlerts);
+
   // Test update threshold
   const updated = updateAlertThreshold(initialAlerts, 'consecutive-failures', 10);
   assert.equal(updated[1].threshold, 10);
 
-  // Test validation - valid
+  // Test update threshold with string value
+  const updatedStr = updateAlertThreshold(initialAlerts, 'consecutive-failures', '7');
+  assert.equal(updatedStr[1].threshold, 7);
+
+  // Test update threshold unknown id returns unchanged list
+  const updatedUnknown = updateAlertThreshold(initialAlerts, 'unknown-id', 99);
+  assert.deepEqual(updatedUnknown, initialAlerts);
+
+  // Test validation - valid alerts pass
   assert.equal(validateAlerts(initialAlerts), null);
 
-  // Test validation - edge case: negative threshold
+  // Test validation - empty list is valid
+  assert.equal(validateAlerts([]), null);
+
+  // Test validation - edge case: negative threshold on enabled alert
   const negativeThreshold = updateAlertThreshold(initialAlerts, 'consecutive-failures', -1);
   assert.equal(validateAlerts(negativeThreshold), 'Invalid threshold for Consecutive Failures. Must be a non-negative number.');
 
-  // Test validation - edge case: percentage exceeds 100
+  // Test validation - edge case: percentage exceeds 100 on enabled alert
   const overPercent = toggleAlert(updateAlertThreshold(initialAlerts, 'crash-rate-spike', 150), 'crash-rate-spike');
   assert.equal(validateAlerts(overPercent), 'Threshold for Crash Rate Spike cannot exceed 100%.');
 
-  // Test validation - edge case: disabled alerts skip validation
+  // Test validation - disabled alerts skip threshold validation
   const disabledInvalid = updateAlertThreshold(initialAlerts, 'crash-rate-spike', -10);
-  // disabled alert should bypass negative threshold error
   assert.equal(validateAlerts(disabledInvalid), null);
+
+  // Test validation - zero threshold is valid (boundary)
+  const zeroThreshold = updateAlertThreshold(initialAlerts, 'consecutive-failures', 0);
+  assert.equal(validateAlerts(zeroThreshold), null);
+
+  // Test validation - exactly 100% threshold is valid (boundary)
+  const maxPercent = toggleAlert(updateAlertThreshold(initialAlerts, 'crash-rate-spike', 100), 'crash-rate-spike');
+  assert.equal(validateAlerts(maxPercent), null);
 };
 
 runAssertions();

--- a/apps/web/src/app/api/webhooks/route.ts
+++ b/apps/web/src/app/api/webhooks/route.ts
@@ -1,0 +1,291 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { WebhookConfig, RunEventType } from '@/app/webhook-manager';
+
+const VALID_PROTOCOLS = new Set(['http:', 'https:']);
+
+const VALID_EVENT_TYPES = new Set<RunEventType>([
+  'run.started',
+  'run.progressing',
+  'run.completed',
+  'run.failed',
+  'run.cancelled',
+  'crash.detected',
+]);
+
+// In-memory store (persists for the lifetime of the process)
+const store = new Map<string, WebhookConfig>();
+
+function isValidUrl(url: unknown): url is string {
+  if (typeof url !== 'string') return false;
+  try {
+    const parsed = new URL(url);
+    return VALID_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function isRunEventType(value: unknown): value is RunEventType {
+  return typeof value === 'string' && VALID_EVENT_TYPES.has(value as RunEventType);
+}
+
+function parseWebhookBody(body: unknown): WebhookConfig | { error: string } {
+  if (typeof body !== 'object' || body === null) {
+    return { error: 'Request body must be a JSON object.' };
+  }
+
+  const raw = body as Record<string, unknown>;
+
+  if (typeof raw.id !== 'string' || !raw.id.trim()) {
+    return { error: 'Field "id" must be a non-empty string.' };
+  }
+
+  if (!isValidUrl(raw.url)) {
+    return { error: 'Field "url" must be a valid http or https URL.' };
+  }
+
+  if (!Array.isArray(raw.events) || raw.events.length === 0) {
+    return { error: 'Field "events" must be a non-empty array.' };
+  }
+
+  if (!raw.events.every(isRunEventType)) {
+    return {
+      error: `Field "events" contains invalid event types. Allowed: ${[...VALID_EVENT_TYPES].join(', ')}.`,
+    };
+  }
+
+  if (typeof raw.active !== 'boolean') {
+    return { error: 'Field "active" must be a boolean.' };
+  }
+
+  const config: WebhookConfig = {
+    id: raw.id.trim(),
+    url: raw.url,
+    events: raw.events as RunEventType[],
+    active: raw.active,
+  };
+
+  if (raw.secret !== undefined) {
+    if (typeof raw.secret !== 'string') {
+      return { error: 'Field "secret" must be a string when provided.' };
+    }
+    config.secret = raw.secret;
+  }
+
+  if (raw.maxRetries !== undefined) {
+    if (typeof raw.maxRetries !== 'number' || !Number.isInteger(raw.maxRetries) || raw.maxRetries < 0) {
+      return { error: 'Field "maxRetries" must be a non-negative integer when provided.' };
+    }
+    config.maxRetries = raw.maxRetries;
+  }
+
+  if (raw.timeoutMs !== undefined) {
+    if (typeof raw.timeoutMs !== 'number' || !Number.isInteger(raw.timeoutMs) || raw.timeoutMs <= 0) {
+      return { error: 'Field "timeoutMs" must be a positive integer when provided.' };
+    }
+    config.timeoutMs = raw.timeoutMs;
+  }
+
+  if (raw.headers !== undefined) {
+    if (
+      typeof raw.headers !== 'object' ||
+      raw.headers === null ||
+      Array.isArray(raw.headers) ||
+      !Object.values(raw.headers as object).every((v) => typeof v === 'string')
+    ) {
+      return { error: 'Field "headers" must be a flat object of string values when provided.' };
+    }
+    config.headers = raw.headers as Record<string, string>;
+  }
+
+  return config;
+}
+
+/**
+ * GET /api/webhooks
+ * Returns all registered webhook configurations.
+ */
+export async function GET() {
+  const webhooks = [...store.values()].map((wh) => ({
+    ...wh,
+    secret: wh.secret !== undefined ? '***' : undefined,
+  }));
+  return NextResponse.json({ webhooks, total: webhooks.length });
+}
+
+/**
+ * POST /api/webhooks
+ * Registers a new webhook. Body: WebhookConfig JSON.
+ */
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Request body must be valid JSON.' }, { status: 400 });
+  }
+
+  const result = parseWebhookBody(body);
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: 422 });
+  }
+
+  if (store.has(result.id)) {
+    return NextResponse.json(
+      { error: `Webhook with id "${result.id}" already exists.` },
+      { status: 409 },
+    );
+  }
+
+  const stored: WebhookConfig = {
+    ...result,
+    maxRetries: result.maxRetries ?? 3,
+    timeoutMs: result.timeoutMs ?? 5000,
+  };
+  store.set(stored.id, stored);
+
+  return NextResponse.json(
+    { ...stored, secret: stored.secret !== undefined ? '***' : undefined },
+    { status: 201 },
+  );
+}
+
+/**
+ * DELETE /api/webhooks?id=<webhookId>
+ * Removes a registered webhook by id.
+ */
+export async function DELETE(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+
+  if (!id || !id.trim()) {
+    return NextResponse.json({ error: 'Query parameter "id" is required.' }, { status: 400 });
+  }
+
+  if (!store.has(id)) {
+    return NextResponse.json({ error: `Webhook "${id}" not found.` }, { status: 404 });
+  }
+
+  store.delete(id);
+  return NextResponse.json({ deleted: id });
+}
+
+/**
+ * PATCH /api/webhooks?id=<webhookId>
+ * Updates an existing webhook. Body: partial WebhookConfig fields.
+ */
+export async function PATCH(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+
+  if (!id || !id.trim()) {
+    return NextResponse.json({ error: 'Query parameter "id" is required.' }, { status: 400 });
+  }
+
+  const existing = store.get(id);
+  if (!existing) {
+    return NextResponse.json({ error: `Webhook "${id}" not found.` }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Request body must be valid JSON.' }, { status: 400 });
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return NextResponse.json({ error: 'Request body must be a JSON object.' }, { status: 400 });
+  }
+
+  const patch = body as Record<string, unknown>;
+  const updated: WebhookConfig = { ...existing };
+
+  if ('url' in patch) {
+    if (!isValidUrl(patch.url)) {
+      return NextResponse.json(
+        { error: 'Field "url" must be a valid http or https URL.' },
+        { status: 422 },
+      );
+    }
+    updated.url = patch.url;
+  }
+
+  if ('events' in patch) {
+    if (!Array.isArray(patch.events) || patch.events.length === 0 || !patch.events.every(isRunEventType)) {
+      return NextResponse.json(
+        { error: `Field "events" must be a non-empty array of valid event types.` },
+        { status: 422 },
+      );
+    }
+    updated.events = patch.events as RunEventType[];
+  }
+
+  if ('active' in patch) {
+    if (typeof patch.active !== 'boolean') {
+      return NextResponse.json({ error: 'Field "active" must be a boolean.' }, { status: 422 });
+    }
+    updated.active = patch.active;
+  }
+
+  if ('secret' in patch) {
+    if (patch.secret !== null && typeof patch.secret !== 'string') {
+      return NextResponse.json(
+        { error: 'Field "secret" must be a string or null.' },
+        { status: 422 },
+      );
+    }
+    updated.secret = patch.secret === null ? undefined : (patch.secret as string);
+  }
+
+  if ('maxRetries' in patch) {
+    if (
+      typeof patch.maxRetries !== 'number' ||
+      !Number.isInteger(patch.maxRetries) ||
+      patch.maxRetries < 0
+    ) {
+      return NextResponse.json(
+        { error: 'Field "maxRetries" must be a non-negative integer.' },
+        { status: 422 },
+      );
+    }
+    updated.maxRetries = patch.maxRetries;
+  }
+
+  if ('timeoutMs' in patch) {
+    if (
+      typeof patch.timeoutMs !== 'number' ||
+      !Number.isInteger(patch.timeoutMs) ||
+      patch.timeoutMs <= 0
+    ) {
+      return NextResponse.json(
+        { error: 'Field "timeoutMs" must be a positive integer.' },
+        { status: 422 },
+      );
+    }
+    updated.timeoutMs = patch.timeoutMs;
+  }
+
+  if ('headers' in patch) {
+    if (
+      patch.headers !== null &&
+      (typeof patch.headers !== 'object' ||
+        Array.isArray(patch.headers) ||
+        !Object.values(patch.headers as object).every((v) => typeof v === 'string'))
+    ) {
+      return NextResponse.json(
+        { error: 'Field "headers" must be a flat object of string values or null.' },
+        { status: 422 },
+      );
+    }
+    updated.headers =
+      patch.headers === null ? undefined : (patch.headers as Record<string, string>);
+  }
+
+  store.set(id, updated);
+
+  return NextResponse.json({
+    ...updated,
+    secret: updated.secret !== undefined ? '***' : undefined,
+  });
+}

--- a/apps/web/src/app/implement-alerting-settings-page-54.tsx
+++ b/apps/web/src/app/implement-alerting-settings-page-54.tsx
@@ -3,32 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { AlertConfig, toggleAlert, updateAlertThreshold, validateAlerts } from './alerting-settings-utils';
 
-const DEFAULT_ALERTS: AlertConfig[] = [
-  {
-    id: 'crash-rate-spike',
-    name: 'Crash Rate Spike',
-    description: 'Alert when the crash rate increases by a certain percentage over a short period.',
-    enabled: true,
-    threshold: 15,
-    unit: '%',
-  },
-  {
-    id: 'resource-exhaustion',
-    name: 'Resource Exhaustion',
-    description: 'Alert when a run consistently hits resource limits (CPU or Memory).',
-    enabled: false,
-    threshold: 90,
-    unit: '%',
-  },
-  {
-    id: 'consecutive-failures',
-    name: 'Consecutive Failures',
-    description: 'Alert when multiple consecutive fuzzing runs fail.',
-    enabled: true,
-    threshold: 5,
-    unit: 'runs',
-  },
-];
+const ALERTING_API_URL = '/api/settings/alerting';
 
 export default function AlertingSettingsPage54() {
   const [alerts, setAlerts] = useState<AlertConfig[]>([]);
@@ -38,15 +13,27 @@ export default function AlertingSettingsPage54() {
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
 
-  // Mock API fetch
   useEffect(() => {
     let isMounted = true;
     const fetchSettings = async () => {
       try {
-        // Simulate network delay
-        await new Promise(resolve => setTimeout(resolve, 800));
+        const response = await fetch(ALERTING_API_URL);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch alerting settings: ${response.status}`);
+        }
+        const data = await response.json();
         if (isMounted) {
-          setAlerts(DEFAULT_ALERTS);
+          const mapped: AlertConfig[] = Array.isArray(data.alertRules)
+            ? data.alertRules.map((rule: { id: string; name: string; description: string; enabled: boolean; threshold: number; unit: string }) => ({
+                id: rule.id,
+                name: rule.name,
+                description: rule.description,
+                enabled: rule.enabled,
+                threshold: rule.threshold,
+                unit: rule.unit,
+              }))
+            : [];
+          setAlerts(mapped);
           setIsLoading(false);
         }
       } catch {
@@ -84,36 +71,59 @@ export default function AlertingSettingsPage54() {
       setValidationError(vErr);
       return;
     }
-    
+
     setIsSaving(true);
     setSaveSuccess(false);
     setError(null);
-    
+
     try {
-      // Simulate API call
-      await new Promise((resolve, reject) => {
-        setTimeout(() => {
-          // 5% chance of mock failure
-          if (Math.random() < 0.05) reject(new Error('Network error'));
-          else resolve(null);
-        }, 1000);
+      const response = await fetch(ALERTING_API_URL, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ alerts }),
       });
-      
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload.error ?? `Save failed with status ${response.status}`);
+      }
+
       setSaveSuccess(true);
-      // Hide success message after 3 seconds
       setTimeout(() => setSaveSuccess(false), 3000);
-    } catch {
-      setError('Failed to save settings. Please try again.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save settings. Please try again.');
     } finally {
       setIsSaving(false);
     }
   };
 
-  const handleReset = () => {
-    setAlerts(DEFAULT_ALERTS);
+  const handleReset = async () => {
     setValidationError(null);
     setError(null);
     setSaveSuccess(false);
+    setIsLoading(true);
+    try {
+      const response = await fetch(ALERTING_API_URL);
+      if (!response.ok) {
+        throw new Error(`Failed to reload alerting settings: ${response.status}`);
+      }
+      const data = await response.json();
+      const mapped: AlertConfig[] = Array.isArray(data.alertRules)
+        ? data.alertRules.map((rule: { id: string; name: string; description: string; enabled: boolean; threshold: number; unit: string }) => ({
+            id: rule.id,
+            name: rule.name,
+            description: rule.description,
+            enabled: rule.enabled,
+            threshold: rule.threshold,
+            unit: rule.unit,
+          }))
+        : [];
+      setAlerts(mapped);
+    } catch {
+      setError('Failed to reload alerting settings.');
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   if (isLoading) {
@@ -156,7 +166,7 @@ export default function AlertingSettingsPage54() {
           Configure threshold alerts for crash rate spikes and other critical events.
         </p>
       </div>
-      
+
       {error && (
         <div className="mx-8 mt-8 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900/50 rounded-lg text-red-700 dark:text-red-400 text-sm font-medium flex items-center gap-2" role="alert">
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -182,15 +192,15 @@ export default function AlertingSettingsPage54() {
               <div className="flex items-center gap-3 mb-2">
                 <h3 className="font-semibold text-lg text-zinc-900 dark:text-zinc-50">{alert.name}</h3>
                 <span className={`px-2.5 py-0.5 text-xs rounded-full font-semibold uppercase tracking-wider ${
-                  alert.enabled 
-                    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400' 
+                  alert.enabled
+                    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400'
                     : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500'
                 }`}>
                   {alert.enabled ? 'Active' : 'Inactive'}
                 </span>
               </div>
               <p className="text-zinc-600 dark:text-zinc-400 leading-relaxed mb-4">{alert.description}</p>
-              
+
               <div className={`transition-all duration-300 overflow-hidden ${alert.enabled ? 'max-h-24 opacity-100' : 'max-h-0 opacity-0'}`}>
                 <div className="flex items-center gap-4 p-4 bg-zinc-50 dark:bg-zinc-800/50 rounded-xl border border-zinc-100 dark:border-zinc-700">
                   <label htmlFor={`threshold-${alert.id}`} className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
@@ -211,7 +221,7 @@ export default function AlertingSettingsPage54() {
                 </div>
               </div>
             </div>
-            
+
             <button
               onClick={() => handleToggle(alert.id)}
               className={`relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 dark:focus:ring-offset-zinc-900 mt-1 ${
@@ -229,7 +239,7 @@ export default function AlertingSettingsPage54() {
           </div>
         ))}
       </div>
-      
+
       <div className="px-8 py-6 bg-zinc-50/50 dark:bg-zinc-900/30 border-t border-zinc-200 dark:border-zinc-800 flex justify-between items-center gap-4">
         <div>
           {saveSuccess && (
@@ -242,14 +252,14 @@ export default function AlertingSettingsPage54() {
           )}
         </div>
         <div className="flex gap-4">
-          <button 
+          <button
             onClick={handleReset}
             disabled={isSaving}
             className="px-6 py-2.5 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 font-medium transition disabled:opacity-50"
           >
             Reset to Default
           </button>
-          <button 
+          <button
             onClick={handleSave}
             disabled={isSaving || !!validationError}
             className="px-8 py-2.5 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 dark:disabled:bg-blue-800 text-white rounded-xl font-bold shadow-lg shadow-blue-200 dark:shadow-none transition transform active:scale-95 disabled:active:scale-100 disabled:cursor-not-allowed flex items-center gap-2"


### PR DESCRIPTION
## Summary

- Replaces all `setTimeout`-based mock fetch calls in `implement-alerting-settings-page-54.tsx` with real `fetch` calls to `GET /api/settings/alerting` (load) and `PUT /api/settings/alerting` (save). The Reset action now reloads live data from the API instead of restoring a hardcoded constant.
- Creates `apps/web/src/app/api/webhooks/route.ts` — a new Next.js Route Handler that persists webhook configurations in process memory. Supports `GET` (list all), `POST` (register), `DELETE` (remove by id), and `PATCH` (partial update). All inputs are validated: URL protocol, event-type allow-list, field types, and duplicate detection. Secrets are masked (`***`) in every response.
- Expands `alerting-settings-utils.test.ts` with additional boundary assertions: unknown-id toggle/update passthrough, string threshold coercion, empty list, zero threshold, and the 100% boundary.

## Test plan

- [ ] `npm run lint` passes in `apps/web`
- [ ] `npm run test` passes in `apps/web`
- [ ] `npm run build` passes in `apps/web`
- [ ] `GET /api/settings/alerting` returns alerting snapshot; `PUT` with a valid body persists and returns the updated snapshot
- [ ] `GET /api/webhooks` returns empty list on fresh process; `POST` with valid body registers and returns the config (secret masked); `DELETE ?id=` removes it; `PATCH ?id=` updates fields
- [ ] Invalid payloads (bad URL, unknown event type, missing required fields, duplicate id) return appropriate 4xx responses
- [ ] Alerting page loads data from the real endpoint and saves without mock delays

Closes #677
Closes #680