### PR TITLE
feat(frontend): invoke replay CLI for runs (ROADMAP-095)

### DIFF
--- a/apps/web/src/app/api/runs/[id]/replay/route.test.ts
+++ b/apps/web/src/app/api/runs/[id]/replay/route.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'node:assert/strict';
+import type { FuzzingRun } from '../../../../types';
+import {
+  buildReplayBundleDocument,
+  buildReplayCliInvocation,
+  serializeReplayBundleDocument,
+} from './route';
+
+const run: FuzzingRun = {
+  id: 'run-1234',
+  status: 'failed',
+  area: 'state',
+  severity: 'high',
+  duration: 1200,
+  seedCount: 42,
+  crashDetail: {
+    failureCategory: 'Panic',
+    signature: 'sig:demo:replay',
+    signatureHash: 123456,
+    payload: JSON.stringify({ contract: 'vault', method: 'rebalance', args: { amount: 7 } }),
+    replayAction: 'cargo run --bin crash-replay -- --run-id run-1234',
+  },
+  cpuInstructions: 1000,
+  memoryBytes: 2048,
+  minResourceFee: 12,
+  queuedAt: '2026-01-01T00:00:00.000Z',
+  startedAt: '2026-01-01T00:00:01.000Z',
+  finishedAt: '2026-01-01T00:00:02.000Z',
+  associatedIssues: [],
+  annotations: [],
+};
+
+const document = buildReplayBundleDocument(run);
+
+assert.equal(document.schema, 2);
+assert.equal(document.seed.id, 1234);
+assert.ok(document.seed.payload.length > 0);
+assert.equal(document.failure_payload.length, document.seed.payload.length);
+assert.equal(typeof document.signature.digest, 'bigint');
+assert.equal(typeof document.signature.signature_hash, 'bigint');
+
+const json = serializeReplayBundleDocument(document);
+assert.match(json, /"schema": 2/);
+assert.match(json, /"seed":\s+\{/);
+assert.match(json, /"digest": \d+/);
+assert.match(json, /"signature_hash": \d+/);
+assert.doesNotMatch(json, /"digest": "/);
+assert.doesNotMatch(json, /"signature_hash": "/);
+
+const invocation = buildReplayCliInvocation('/tmp/crashlab-replay/demo.json');
+assert.equal(invocation.command, 'cargo');
+assert.deepEqual(invocation.args.slice(0, 6), [
+  'run',
+  '--quiet',
+  '--manifest-path',
+  invocation.args[3],
+  '--bin',
+  'crashlab',
+]);
+assert.equal(invocation.args[invocation.args.length - 3], 'replay');
+assert.equal(invocation.args[invocation.args.length - 2], 'seed');
+assert.equal(invocation.args[invocation.args.length - 1], '/tmp/crashlab-replay/demo.json');
+
+console.log('route.test.ts: all assertions passed');

--- a/apps/web/src/app/api/runs/[id]/replay/route.ts
+++ b/apps/web/src/app/api/runs/[id]/replay/route.ts
@@ -1,0 +1,362 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { randomUUID } from 'node:crypto';
+import { buildMockRuns } from '../../../../mockRuns';
+import type { FuzzingRun } from '../../../../types';
+
+export const runtime = 'nodejs';
+
+const execFileAsync = promisify(execFile);
+const FNV64_OFFSET = 0xcbf29ce484222325n;
+const FNV64_PRIME = 0x100000001b3n;
+const FIELD_SEPARATOR = 0x1en;
+
+type ReplayCategory =
+  | 'auth'
+  | 'budget'
+  | 'state'
+  | 'xdr'
+  | 'invalid-enum-tag'
+  | 'empty-input'
+  | 'oversized-input'
+  | 'unknown';
+
+interface ReplayBundleDocument {
+  schema: number;
+  seed: {
+    id: number;
+    payload: number[];
+  };
+  signature: {
+    category: string;
+    digest: bigint;
+    signature_hash: bigint;
+  };
+  environment: null;
+  failure_payload: number[];
+  rpc_envelope: null;
+}
+
+interface ReplayInvocationResult {
+  command: string;
+  args: string[];
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export function findRunById(id: string): FuzzingRun | undefined {
+  return buildMockRuns().find((run) => run.id === id);
+}
+
+function stableRunIdSeed(runId: string): number {
+  const trailingDigits = runId.match(/(\d+)$/)?.[1];
+  if (trailingDigits) {
+    return Number.parseInt(trailingDigits, 10);
+  }
+
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < runId.length; index += 1) {
+    hash ^= runId.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+function classifyReplayPayload(payload: Uint8Array): ReplayCategory {
+  if (payload.length === 0) {
+    return 'empty-input';
+  }
+
+  if (payload.length > 64) {
+    return 'oversized-input';
+  }
+
+  const first = payload[0];
+  if (first <= 0x1f) {
+    return 'xdr';
+  }
+  if (first <= 0x5f) {
+    return 'state';
+  }
+  if (first <= 0x9f) {
+    return 'budget';
+  }
+  return 'auth';
+}
+
+function fnv1a64(bytes: Iterable<number>, initialState = FNV64_OFFSET): bigint {
+  let hash = initialState;
+  for (const byte of bytes) {
+    hash ^= BigInt(byte);
+    hash = (hash * FNV64_PRIME) & 0xffffffffffffffffn;
+  }
+  return hash;
+}
+
+function utf8Bytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function hexBytes(payload: Uint8Array): Uint8Array {
+  const hex = Buffer.from(payload).toString('hex');
+  return utf8Bytes(hex);
+}
+
+function computeSignatureHash(category: string, payload: Uint8Array): bigint {
+  let hash = fnv1a64(utf8Bytes(category));
+  hash = fnv1a64([Number(FIELD_SEPARATOR)], hash);
+  hash = fnv1a64(utf8Bytes('__payload__'), hash);
+  hash = fnv1a64([Number(FIELD_SEPARATOR)], hash);
+  return fnv1a64(hexBytes(payload), hash);
+}
+
+function computeDigest(seedId: number, payload: Uint8Array): bigint {
+  let digest = BigInt(seedId) & 0xffffffffffffffffn;
+  for (const byte of payload) {
+    digest = (digest * FNV64_PRIME + BigInt(byte)) & 0xffffffffffffffffn;
+  }
+  return digest;
+}
+
+function indentBlock(value: string, indent: string): string {
+  return value
+    .split('\n')
+    .map((line) => `${indent}${line}`)
+    .join('\n');
+}
+
+export function buildReplayBundleDocument(run: FuzzingRun): ReplayBundleDocument {
+  if (!run.crashDetail) {
+    throw new Error(`run ${run.id} does not include crash details`);
+  }
+
+  const payload = utf8Bytes(run.crashDetail.payload);
+  const category = classifyReplayPayload(payload);
+  const seedId = stableRunIdSeed(run.id);
+  const digest = computeDigest(seedId, payload);
+  const signatureHash = computeSignatureHash(category, payload);
+
+  return {
+    schema: 2,
+    seed: {
+      id: seedId,
+      payload: Array.from(payload),
+    },
+    signature: {
+      category,
+      digest,
+      signature_hash: signatureHash,
+    },
+    environment: null,
+    failure_payload: Array.from(payload),
+    rpc_envelope: null,
+  };
+}
+
+export function serializeReplayBundleDocument(document: ReplayBundleDocument): string {
+  const seedJson = JSON.stringify(document.seed, null, 2);
+  const failurePayloadJson = JSON.stringify(document.failure_payload, null, 2);
+
+  return [
+    '{',
+    `  "schema": ${document.schema},`,
+    `  "seed": ${indentBlock(seedJson, '  ')},`,
+    '  "signature": {',
+    `    "category": ${JSON.stringify(document.signature.category)},`,
+    `    "digest": ${document.signature.digest.toString()},`,
+    `    "signature_hash": ${document.signature.signature_hash.toString()}`,
+    '  },',
+    '  "environment": null,',
+    `  "failure_payload": ${indentBlock(failurePayloadJson, '  ')},`,
+    '  "rpc_envelope": null',
+    '}',
+  ].join('\n');
+}
+
+export function buildReplayCliInvocation(bundlePath: string): { command: string; args: string[] } {
+  const manifestPath = path.resolve(
+    process.cwd(),
+    '..',
+    '..',
+    'contracts',
+    'crashlab-core',
+    'Cargo.toml',
+  );
+
+  return {
+    command: 'cargo',
+    args: [
+      'run',
+      '--quiet',
+      '--manifest-path',
+      manifestPath,
+      '--bin',
+      'crashlab',
+      '--',
+      'replay',
+      'seed',
+      bundlePath,
+    ],
+  };
+}
+
+async function writeReplayBundleFile(run: FuzzingRun): Promise<{ bundlePath: string; document: ReplayBundleDocument }> {
+  const document = buildReplayBundleDocument(run);
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crashlab-replay-'));
+  const bundlePath = path.join(tempDir, `${run.id}.json`);
+  await fs.writeFile(bundlePath, serializeReplayBundleDocument(document), 'utf8');
+  return { bundlePath, document };
+}
+
+async function executeReplayCli(bundlePath: string): Promise<ReplayInvocationResult> {
+  const { command, args } = buildReplayCliInvocation(bundlePath);
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, {
+      maxBuffer: 10 * 1024 * 1024,
+      windowsHide: true,
+    });
+    return {
+      command,
+      args,
+      stdout,
+      stderr,
+      exitCode: 0,
+    };
+  } catch (error) {
+    const exitCode = typeof error === 'object' && error !== null && 'code' in error && typeof error.code === 'number'
+      ? error.code
+      : 1;
+    const stdout = typeof error === 'object' && error !== null && 'stdout' in error && typeof error.stdout === 'string'
+      ? error.stdout
+      : '';
+    const stderr = typeof error === 'object' && error !== null && 'stderr' in error && typeof error.stderr === 'string'
+      ? error.stderr
+      : (error instanceof Error ? error.message : '');
+
+    return {
+      command,
+      args,
+      stdout,
+      stderr,
+      exitCode,
+    };
+  }
+}
+
+async function resolveReplayRun(runId: string): Promise<FuzzingRun | null> {
+  const runsApiUrl = process.env.RUNS_API_URL;
+
+  if (runsApiUrl) {
+    const upstream = await fetch(`${runsApiUrl}/runs/${encodeURIComponent(runId)}`, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+
+    if (upstream.status === 404) {
+      return null;
+    }
+
+    if (!upstream.ok) {
+      throw new Error(`upstream run lookup failed with HTTP ${upstream.status}`);
+    }
+
+    return (await upstream.json()) as FuzzingRun;
+  }
+
+  return findRunById(runId) ?? null;
+}
+
+function replayFailureStatus(stderr: string): number {
+  if (stderr.includes('replay mismatch:')) {
+    return 409;
+  }
+
+  return 502;
+}
+
+function buildReplayRunId(sourceRunId: string): string {
+  return `replay-${sourceRunId}-${randomUUID().slice(0, 8)}`;
+}
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  if (!id) {
+    return NextResponse.json({ error: 'Run ID is required' }, { status: 400 });
+  }
+
+  try {
+    const run = await resolveReplayRun(id);
+    const newRunId = buildReplayRunId(id);
+
+    if (!run) {
+      return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+    }
+
+    if (!run.crashDetail) {
+      return NextResponse.json(
+        { error: 'Run does not include replayable crash details' },
+        { status: 422 },
+      );
+    }
+
+    const { bundlePath, document } = await writeReplayBundleFile(run);
+    const tempDir = path.dirname(bundlePath);
+    const bundleJson = serializeReplayBundleDocument(document);
+
+    try {
+      const cli = await executeReplayCli(bundlePath);
+
+      if (cli.exitCode !== 0) {
+        return NextResponse.json(
+          {
+            ok: false,
+            runId: run.id,
+            newRunId,
+            bundleJson,
+            command: cli.command,
+            args: cli.args,
+            stdout: cli.stdout,
+            stderr: cli.stderr,
+            exitCode: cli.exitCode,
+          },
+          { status: replayFailureStatus(cli.stderr) },
+        );
+      }
+
+      return NextResponse.json(
+        {
+          ok: true,
+          runId: run.id,
+          newRunId,
+          bundleJson,
+          command: cli.command,
+          args: cli.args,
+          stdout: cli.stdout,
+          stderr: cli.stderr,
+          exitCode: cli.exitCode,
+        },
+        { status: 200 },
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  } catch (error) {
+    console.error('POST /api/runs/[id]/replay failed:', error);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Failed to start replay',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/replay-ui-utils.test.ts
+++ b/apps/web/src/app/replay-ui-utils.test.ts
@@ -1,92 +1,89 @@
-import { simulateSeedReplay } from "./replay";
+import * as assert from 'node:assert/strict';
+import { simulateSeedReplay } from './replay';
 import {
   createReplayPlaceholderRun,
   getReplayButtonLabel,
-  ReplayActionData,
-  ReplayButtonStatus,
-} from "./replay-ui-utils";
+  type ReplayActionData,
+  type ReplayButtonStatus,
+} from './replay-ui-utils';
 
-describe("getReplayButtonLabel", () => {
-  it("returns replay label for idle", () => {
-    expect(getReplayButtonLabel("idle")).toBe("Replay");
-  });
+function testGetReplayButtonLabel() {
+  assert.equal(getReplayButtonLabel('idle'), 'Replay');
+  assert.equal(getReplayButtonLabel('loading'), 'Replaying...');
+  assert.equal(getReplayButtonLabel('success'), 'Replay queued');
+  assert.equal(getReplayButtonLabel('error'), 'Retry replay');
 
-  it("returns replaying label for loading", () => {
-    expect(getReplayButtonLabel("loading")).toBe("Replaying...");
-  });
+  const statuses: ReplayButtonStatus[] = ['idle', 'loading', 'success', 'error'];
+  const labels = statuses.map((status) => getReplayButtonLabel(status));
+  assert.deepEqual(labels, ['Replay', 'Replaying...', 'Replay queued', 'Retry replay']);
+}
 
-  it("returns queued label for success", () => {
-    expect(getReplayButtonLabel("success")).toBe("Replay queued");
-  });
+function testCreateReplayPlaceholderRun() {
+  const data: ReplayActionData = { id: 'replay-run-1', status: 'running' };
+  const run = createReplayPlaceholderRun(data);
 
-  it("returns retry label for error", () => {
-    expect(getReplayButtonLabel("error")).toBe("Retry replay");
-  });
+  assert.equal(run.id, 'replay-run-1');
+  assert.equal(run.status, 'running');
+  assert.equal(run.area, 'state');
+  assert.equal(run.severity, 'medium');
 
-  it("maps all valid statuses without fallback gaps", () => {
-    const statuses: ReplayButtonStatus[] = [
-      "idle",
-      "loading",
-      "success",
-      "error",
-    ];
-    const labels = statuses.map((status) => getReplayButtonLabel(status));
-    expect(labels).toEqual([
-      "Replay",
-      "Replaying...",
-      "Replay queued",
-      "Retry replay",
-    ]);
-  });
-});
+  const defaultRun = createReplayPlaceholderRun({ id: 'replay-run-2', status: 'running' });
+  assert.equal(defaultRun.duration, 0);
+  assert.equal(defaultRun.seedCount, 0);
+  assert.equal(defaultRun.cpuInstructions, 0);
+  assert.equal(defaultRun.memoryBytes, 0);
+  assert.equal(defaultRun.minResourceFee, 0);
+  assert.equal(defaultRun.crashDetail, null);
+}
 
-describe("createReplayPlaceholderRun", () => {
-  it("creates a running placeholder run from replay action data", () => {
-    const data: ReplayActionData = { id: "replay-run-1", status: "running" };
-    const run = createReplayPlaceholderRun(data);
+async function testReplayServiceMapping() {
+  const originalFetch = globalThis.fetch;
+  const fetchMock = async (input: RequestInfo | URL, init?: RequestInit) => {
+    assert.ok(String(input).includes('/api/runs/run-42/replay'));
+    assert.equal(init?.method, 'POST');
 
-    expect(run.id).toBe("replay-run-1");
-    expect(run.status).toBe("running");
-    expect(run.area).toBe("state");
-    expect(run.severity).toBe("medium");
-  });
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        runId: 'run-42',
+        newRunId: 'replay-run-42-abc12345',
+        command: 'cargo',
+        args: ['run'],
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        bundleJson: '{}',
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  };
 
-  it("sets safe default metrics for placeholder run", () => {
-    const run = createReplayPlaceholderRun({
-      id: "replay-run-2",
-      status: "running",
-    });
+  globalThis.fetch = fetchMock as typeof globalThis.fetch;
 
-    expect(run.duration).toBe(0);
-    expect(run.seedCount).toBe(0);
-    expect(run.cpuInstructions).toBe(0);
-    expect(run.memoryBytes).toBe(0);
-    expect(run.minResourceFee).toBe(0);
-    expect(run.crashDetail).toBeNull();
-  });
-});
-
-describe("integration: replay service to dashboard run mapping", () => {
-  it("maps simulateSeedReplay output into a dashboard-compatible run", async () => {
-    const replayResult = await simulateSeedReplay("run-42");
+  try {
+    const replayResult = await simulateSeedReplay('run-42');
     const run = createReplayPlaceholderRun({
       id: replayResult.newRunId,
-      status: "running",
+      status: 'running',
     });
 
-    expect(run.id.startsWith("replay-run-42-")).toBe(true);
-    expect(run.status).toBe("running");
-    expect(run.crashDetail).toBeNull();
-    expect(run.area).toBe("state");
-  });
+    assert.ok(run.id.startsWith('replay-run-42-'));
+    assert.equal(run.status, 'running');
+    assert.equal(run.crashDetail, null);
+    assert.equal(run.area, 'state');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
 
-  it("preserves run id exactly when injected from replay action callback", () => {
-    const callbackPayload: ReplayActionData = {
-      id: "replay-run-99-abc12345",
-      status: "running",
-    };
+async function main() {
+  testGetReplayButtonLabel();
+  testCreateReplayPlaceholderRun();
+  await testReplayServiceMapping();
+  console.log('replay-ui-utils.test.ts: all assertions passed');
+}
 
-    const run = createReplayPlaceholderRun(callbackPayload);
-    expect(run.id).toBe(callbackPayload.id);
-  });
-});
+void main();

--- a/apps/web/src/app/replay.ts
+++ b/apps/web/src/app/replay.ts
@@ -1,10 +1,36 @@
+export interface ReplayApiResponse {
+    ok: boolean;
+    runId: string;
+    newRunId: string;
+    command: string;
+    args: string[];
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+    bundleJson: string;
+    error?: string;
+}
+
 /**
- * Simulates scheduling a seed replay for the dashboard (no backend in this demo).
+ * Invokes the replay API for a source run and returns the queued replay run id.
  */
 export async function simulateSeedReplay(sourceRunId: string): Promise<{ newRunId: string }> {
-    await new Promise((resolve) => setTimeout(resolve, 900));
-    const suffix = typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID().slice(0, 8)
-        : Math.random().toString(36).slice(2, 10);
-    return { newRunId: `replay-${sourceRunId}-${suffix}` };
+    const response = await fetch(`/api/runs/${encodeURIComponent(sourceRunId)}/replay`, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+        },
+    });
+
+    const payload = (await response.json()) as Partial<ReplayApiResponse>;
+
+    if (!response.ok || !payload.ok || typeof payload.newRunId !== 'string') {
+        throw new Error(
+            typeof payload.error === 'string'
+                ? payload.error
+                : `Replay request failed with HTTP ${response.status}`,
+        );
+    }
+
+    return { newRunId: payload.newRunId };
 }


### PR DESCRIPTION
Summary:
- Adds POST /api/runs/[id]/replay as a real Node.js route that resolves the run, writes a temporary replay bundle, and invokes the Rust CLI via `cargo run`.
- Replaces the replay timer shim with a fetch-based API call from the dashboard replay helper.
- Updates replay utility coverage to exercise the API-backed flow.

Closes #682

Manual test steps:
1. Open a failed run in the dashboard and trigger replay from the crash drawer.
2. Confirm the API returns a queued replay run id and the UI updates to the new replay link.
3. Re-run the focused replay route and replay utility tests if you change the adapter again.

Validation:
- `cd apps/web && npm ci`
- `cd apps/web && ./node_modules/.bin/tsc src/app/api/runs/[id]/replay/route.ts src/app/api/runs/[id]/replay/route.test.ts src/app/replay.ts src/app/replay-ui-utils.ts src/app/replay-ui-utils.test.ts src/app/types.ts src/app/mockRuns.ts --module commonjs --target es2020 --rootDir src --outDir build/test-tmp --esModuleInterop --skipLibCheck && node build/test-tmp/app/api/runs/[id]/replay/route.test.js && node build/test-tmp/app/replay-ui-utils.test.js`