### PR TITLE
CI Replay

### DIFF
--- a/apps/web/src/app/integrations/ci-replay/page.tsx
+++ b/apps/web/src/app/integrations/ci-replay/page.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import CIIntegrationForRunReplayTests from '../../integrate-ci-integration-for-run-replay-tests';
+
+export const metadata = {
+  title: 'CI Replay Integration | SorobanCrashLab',
+  description: 'Dashboard panel for dispatching and inspecting CI pipeline replay tests for fuzzing seeds.',
+};
+
+export default function CIReplayIntegrationPage() {
+  return (
+    <div className="mx-auto max-w-7xl p-4 sm:p-6 lg:p-8">
+      <CIIntegrationForRunReplayTests />
+    </div>
+  );
+}

--- a/apps/web/src/app/integrations/page.tsx
+++ b/apps/web/src/app/integrations/page.tsx
@@ -81,6 +81,19 @@ const INTEGRATIONS: Integration[] = [
     category: 'Triage'
   },
   {
+    id: 'ci',
+    title: 'CI Integration',
+    description: 'Integrate with CI/CD pipelines to run fuzzing tests automatically on code changes.',
+    icon: (
+      <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
+      </svg>
+    ),
+    href: '/integrations/ci-replay',
+    status: 'available',
+    category: 'DevOps'
+  },
+  {
     id: 'webhooks',
     title: 'Webhook Manager',
     description: 'Configure external endpoints to receive real-time notifications for fuzzing run lifecycle events.',
@@ -118,19 +131,6 @@ const INTEGRATIONS: Integration[] = [
     href: '#auth',
     status: 'coming-soon',
     category: 'Security'
-  },
-  {
-    id: 'ci',
-    title: 'CI Integration',
-    description: 'Integrate with CI/CD pipelines to run fuzzing tests automatically on code changes.',
-    icon: (
-      <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
-      </svg>
-    ),
-    href: '#ci',
-    status: 'coming-soon',
-    category: 'DevOps'
   }
 ];
 


### PR DESCRIPTION
## Summary

- Added a new page for `/inegrations/ci-replay` that mounts the pre-built `CIIntegrationForRunReplayTests`
- Updated the status of CI Replay to available in integrations page

Closes #684 

## Checklist

- [ ] Branch name follows `issue/<number>-<slug>`
- [x] Scope limited to files listed in the issue
- [ ] Tests added or updated
- [x] `pnpm-lock.yaml` / `package-lock.json` **not** modified
- [ ] If `package.json` changed: maintainer approval requested below


https://github.com/user-attachments/assets/2bb6de08-4030-4756-ae69-4594a24168cc

