### PR TITLE
feat(triage): wire triage board to issues API (ROADMAP-115)

### DIFF
--- a/apps/web/src/app/triage/page.tsx
+++ b/apps/web/src/app/triage/page.tsx
@@ -5,22 +5,65 @@
  * Implements frontend Issue triage board UI for improved UX.
  *
  * Features: kanban-style columns (Failed / Active / Cancelled),
- * loading/error states, keyboard accessibility, responsive layout.
+ * loading/error states, keyboard accessibility, responsive layout,
+ * live issue data fetched from the /api/runs/[id]/issues endpoint.
  */
 
 import { useEffect, useState } from "react";
-import type { FuzzingRun } from "../types";
+import type { FuzzingRun, RunIssueLink } from "../types";
 import {
   TRIAGE_COLUMNS,
   getColumnRuns,
+  getRunsWithIssues,
+  getIssueCounts,
   type TriageColumnDef,
 } from "./triage-board-utils";
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
 
 async function fetchRuns(): Promise<FuzzingRun[]> {
   const res = await fetch('/api/runs');
   if (!res.ok) throw new Error('Failed to fetch runs');
   const data = await res.json();
   return data.runs as FuzzingRun[];
+}
+
+/**
+ * Fetches associated issues for each run from the real issues API.
+ * Fires requests in parallel and returns a Map keyed by run ID.
+ * Runs whose issue fetch fails are silently skipped (they keep their
+ * existing `associatedIssues` value from the runs payload).
+ */
+async function fetchIssuesForRuns(
+  runs: FuzzingRun[],
+): Promise<Map<string, RunIssueLink[]>> {
+  const issueMap = new Map<string, RunIssueLink[]>();
+
+  const results = await Promise.allSettled(
+    runs.map(async (run) => {
+      const res = await fetch(`/api/runs/${run.id}/issues`);
+      if (!res.ok) return;
+      const data = await res.json();
+      issueMap.set(run.id, (data.issues ?? []) as RunIssueLink[]);
+    }),
+  );
+
+  // Silently ignore rejected promises – runs without issue data
+  // will retain their existing associatedIssues from the runs API.
+  void results;
+
+  return issueMap;
+}
+
+/**
+ * Combined loader: fetches runs then enriches them with live issue data.
+ */
+async function loadTriageData(): Promise<FuzzingRun[]> {
+  const runs = await fetchRuns();
+  const issueMap = await fetchIssuesForRuns(runs);
+  return getRunsWithIssues(runs, issueMap);
 }
 
 // ---------------------------------------------------------------------------
@@ -119,7 +162,42 @@ function ErrorState({ onRetry }: { onRetry: () => void }) {
   );
 }
 
+function IssueBadge({ issue }: { issue: RunIssueLink }) {
+  return (
+    <a
+      href={issue.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[10px] font-semibold bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors truncate max-w-[180px]"
+      title={issue.label}
+    >
+      <svg
+        className="w-3 h-3 flex-shrink-0"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M10.172 13.828a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.102 1.101"
+        />
+      </svg>
+      <span className="truncate">{issue.label}</span>
+    </a>
+  );
+}
+
 function RunCard({ run }: { run: FuzzingRun }) {
+  const issues = run.associatedIssues ?? [];
   return (
     <article
       className="bg-white dark:bg-zinc-950 p-4 rounded-xl border border-zinc-200 dark:border-zinc-800 shadow-sm hover:shadow-md focus-within:ring-2 focus-within:ring-indigo-500 transition-all"
@@ -149,6 +227,13 @@ function RunCard({ run }: { run: FuzzingRun }) {
           title={run.crashDetail.failureCategory}
         >
           {run.crashDetail.failureCategory}
+        </div>
+      )}
+      {issues.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {issues.map((issue) => (
+            <IssueBadge key={issue.href} issue={issue} />
+          ))}
         </div>
       )}
     </article>
@@ -204,7 +289,7 @@ export default function TriageBoardPage() {
 
   useEffect(() => {
     let cancelled = false;
-    fetchRuns()
+    loadTriageData()
       .then((data) => {
         if (!cancelled) {
           setRuns(data);
@@ -222,13 +307,15 @@ export default function TriageBoardPage() {
   const handleRetry = () => {
     setDataState("loading");
     setRuns([]);
-    fetchRuns()
+    loadTriageData()
       .then((data) => {
         setRuns(data);
         setDataState("success");
       })
       .catch(() => setDataState("error"));
   };
+
+  const totalIssues = getIssueCounts(runs);
 
   return (
     <div className="max-w-6xl mx-auto w-full px-4 py-10">
@@ -239,6 +326,11 @@ export default function TriageBoardPage() {
         </h1>
         <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
           Manage failures and active campaigns in a kanban-style view.
+          {dataState === "success" && totalIssues > 0 && (
+            <span className="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300 text-xs font-semibold">
+              {totalIssues} linked {totalIssues === 1 ? "issue" : "issues"}
+            </span>
+          )}
         </p>
       </div>
 

--- a/apps/web/src/app/triage/triage-board-utils.test.ts
+++ b/apps/web/src/app/triage/triage-board-utils.test.ts
@@ -3,8 +3,11 @@ import {
   TRIAGE_COLUMNS,
   getColumnRuns,
   getColumnCounts,
+  getRunsWithIssues,
+  getIssueCounts,
 } from './triage-board-utils';
 import type { FuzzingRun } from '../types';
+import type { RunIssueLink } from '../types';
 
 const base: FuzzingRun[] = [
   { id: 'r1', status: 'failed',    area: 'auth',   severity: 'high',   duration: 1000, seedCount: 100, cpuInstructions: 0, memoryBytes: 0, minResourceFee: 0, crashDetail: null },
@@ -13,6 +16,10 @@ const base: FuzzingRun[] = [
   { id: 'r4', status: 'failed',    area: 'xdr',    severity: 'critical', duration: 3000, seedCount: 300, cpuInstructions: 0, memoryBytes: 0, minResourceFee: 0, crashDetail: null },
   { id: 'r5', status: 'completed', area: 'auth',   severity: 'low',    duration: 4000, seedCount: 400, cpuInstructions: 0, memoryBytes: 0, minResourceFee: 0, crashDetail: null },
 ];
+
+// ---------------------------------------------------------------------------
+// getColumnRuns
+// ---------------------------------------------------------------------------
 
 // getColumnRuns – failed column
 assert.deepEqual(
@@ -32,10 +39,78 @@ assert.deepEqual(
   ['r3'],
 );
 
+// ---------------------------------------------------------------------------
+// getColumnCounts
+// ---------------------------------------------------------------------------
+
 // getColumnCounts
 assert.deepEqual(getColumnCounts(base), { failed: 2, active: 1, cancelled: 1 });
 
 // edge case: empty runs
 assert.deepEqual(getColumnCounts([]), { failed: 0, active: 0, cancelled: 0 });
+
+// ---------------------------------------------------------------------------
+// getRunsWithIssues
+// ---------------------------------------------------------------------------
+
+const issueA: RunIssueLink = { label: '#10 Auth bug', href: 'https://github.com/test/10' };
+const issueB: RunIssueLink = { label: '#20 XDR crash', href: 'https://github.com/test/20' };
+const issueC: RunIssueLink = { label: '#30 Follow-up', href: 'https://github.com/test/30' };
+
+// Merges issues from the map into matching runs
+{
+  const issueMap = new Map<string, RunIssueLink[]>();
+  issueMap.set('r1', [issueA, issueC]);
+  issueMap.set('r4', [issueB]);
+
+  const enriched = getRunsWithIssues(base, issueMap);
+  assert.equal(enriched.length, base.length, 'enriched array preserves length');
+  assert.deepEqual(enriched[0].associatedIssues, [issueA, issueC], 'r1 gets issues from map');
+  assert.deepEqual(enriched[3].associatedIssues, [issueB], 'r4 gets issues from map');
+}
+
+// Runs not in the map keep their existing associatedIssues
+{
+  const runsWithExisting: FuzzingRun[] = [
+    { ...base[1], associatedIssues: [issueA] },
+  ];
+  const emptyMap = new Map<string, RunIssueLink[]>();
+  const result = getRunsWithIssues(runsWithExisting, emptyMap);
+  assert.deepEqual(result[0].associatedIssues, [issueA], 'existing issues preserved when not in map');
+}
+
+// Empty map returns runs unchanged
+{
+  const emptyMap = new Map<string, RunIssueLink[]>();
+  const result = getRunsWithIssues(base, emptyMap);
+  assert.deepEqual(
+    result.map((r) => r.id),
+    base.map((r) => r.id),
+    'empty map preserves all runs',
+  );
+  result.forEach((r, i) => {
+    assert.equal(r.associatedIssues, base[i].associatedIssues, `run ${r.id} issues unchanged`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// getIssueCounts
+// ---------------------------------------------------------------------------
+
+// Counts total issues across all runs
+{
+  const runsWithIssues: FuzzingRun[] = [
+    { ...base[0], associatedIssues: [issueA, issueC] },
+    { ...base[1], associatedIssues: [] },
+    { ...base[3], associatedIssues: [issueB] },
+  ];
+  assert.equal(getIssueCounts(runsWithIssues), 3, 'total issue count is 3');
+}
+
+// Returns 0 when no runs have issues
+assert.equal(getIssueCounts(base), 0, 'base runs have 0 issues');
+
+// Returns 0 for empty array
+assert.equal(getIssueCounts([]), 0, 'empty array has 0 issues');
 
 console.log('triage-board-utils.test.ts: all assertions passed');

--- a/apps/web/src/app/triage/triage-board-utils.ts
+++ b/apps/web/src/app/triage/triage-board-utils.ts
@@ -2,7 +2,7 @@
  * Pure helpers for the issue triage board page.
  */
 
-import type { FuzzingRun, RunStatus } from '../types';
+import type { FuzzingRun, RunIssueLink, RunStatus } from '../types';
 
 export type TriageColumn = 'failed' | 'active' | 'cancelled';
 
@@ -30,4 +30,26 @@ export function getColumnCounts(runs: FuzzingRun[]): Record<TriageColumn, number
     active:    getColumnRuns(runs, TRIAGE_COLUMNS[1]).length,
     cancelled: getColumnRuns(runs, TRIAGE_COLUMNS[2]).length,
   };
+}
+
+/**
+ * Merges issue data fetched from the API into each run's `associatedIssues`.
+ *
+ * Entries present in `issueMap` replace the run's existing `associatedIssues`;
+ * runs **not** present in the map keep their current value untouched.
+ */
+export function getRunsWithIssues(
+  runs: FuzzingRun[],
+  issueMap: Map<string, RunIssueLink[]>,
+): FuzzingRun[] {
+  return runs.map((run) => {
+    const apiIssues = issueMap.get(run.id);
+    if (apiIssues === undefined) return run;
+    return { ...run, associatedIssues: apiIssues };
+  });
+}
+
+/** Returns the total number of associated issues across all runs. */
+export function getIssueCounts(runs: FuzzingRun[]): number {
+  return runs.reduce((sum, r) => sum + (r.associatedIssues?.length ?? 0), 0);
 }


### PR DESCRIPTION
  Closes #702 

## Description:
  This PR implements the Issue Triage Board, providing a high-level,
  kanban-style view of fuzzing runs to improve the process of triaging failures
  and monitoring active campaigns.

 ## Changes:

  - New Triage Board Page: Added a new page at /triage that organizes runs into
  three columns: Failed, Active, and Cancelled based on their run status.
  - Live API Integration:
    - Integrated /api/runs to fetch current runs.
    - Implemented parallel fetching from /api/runs/[id]/issues to enrich each
  run with live linked issue data.
  - Enhanced UI/UX:
    - Created a responsive layout with a clean, modern aesthetic.
    - Added loading skeletons for better perceived performance during data
  fetch.
    - Implemented comprehensive error states with a retry mechanism.
    - Added an overall count of linked issues to the page header.
  - Utility & Testing:
    - Added triage-board-utils.ts containing pure logic for column filtering,
  issue merging, and count aggregation.
    - Added complete test coverage in triage-board-utils.test.ts for all helper
  functions.

