### PR TITLE
feat(contracts): add RpcContractRunner stub for RPC URL (ROADMAP-023) (#610)

### DIFF
--- a/contracts/crashlab-core/src/lib.rs
+++ b/contracts/crashlab-core/src/lib.rs
@@ -11,6 +11,8 @@ pub mod fixture_classifier;
 pub mod suite_runner;
 pub mod runner;
 
+pub use runner::{ContractRunner, RunnerError, RunnerCreationError, create_runner, MockRunner};
+
 #[cfg(feature = "host-runner")]
 pub mod host_runner;
 

--- a/contracts/crashlab-core/src/lib.rs
+++ b/contracts/crashlab-core/src/lib.rs
@@ -16,6 +16,8 @@ pub use runner::{ContractRunner, RunnerError, RunnerCreationError, create_runner
 #[cfg(feature = "host-runner")]
 pub mod host_runner;
 
+pub mod rpc_runner;
+
 pub use auth_matrix::{
 
     AuthMode, MatrixReport, ModeResult, collect_mismatched, format_mismatch_summary, run_matrix,
@@ -42,6 +44,8 @@ pub use suite_runner::{GroupSummary, GroupStats, SuiteRunnerConfig};
 
 #[cfg(feature = "host-runner")]
 pub use host_runner::HostContractRunner;
+
+pub use rpc_runner::{RpcContractRunner, RpcConfigError};
 
 pub mod seed_validator;
 pub use seed_validator::{SeedSchema, SeedValidationError, Validate};

--- a/contracts/crashlab-core/src/rpc_runner.rs
+++ b/contracts/crashlab-core/src/rpc_runner.rs
@@ -1,0 +1,334 @@
+//! RPC-based contract runner for executing seeds against a Soroban RPC endpoint.
+//!
+//! This module provides [`RpcContractRunner`], an implementation of [`ContractRunner`]
+//! that executes contract calls against a Soroban RPC endpoint.
+//!
+//! # Purpose
+//! The RPC runner enables testing against live or test Soroban networks without
+//! requiring a local contract environment setup. It communicates with a Soroban RPC
+//! endpoint to execute contract methods and capture the resulting signatures.
+//!
+//! # Usage
+//! ```rust,no_run
+//! use crashlab_core::{CaseSeed, RpcContractRunner};
+//!
+//! let mut runner = RpcContractRunner::new("https://rpc-futurenet.stellar.org:443")?;
+//! let seed = CaseSeed { id: 1, payload: vec![1, 2, 3] };
+//! let signature = runner.run_seed(&seed)?;
+//! ```
+
+use crate::{CaseSeed, CrashSignature};
+use crate::runner::{RunnerError, ContractRunner};
+
+/// Configuration error for RPC runner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RpcConfigError {
+    /// The provided RPC URL is invalid or empty.
+    InvalidUrl {
+        /// Description of what makes the URL invalid.
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for RpcConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RpcConfigError::InvalidUrl { reason } => {
+                write!(f, "invalid RPC URL: {}", reason)
+            }
+        }
+    }
+}
+
+impl std::error::Error for RpcConfigError {}
+
+/// A contract runner that executes seeds against a Soroban RPC endpoint.
+///
+/// `RpcContractRunner` connects to a Soroban RPC endpoint and executes contract
+/// calls through that endpoint. This allows testing against live or test networks.
+///
+/// # Configuration
+/// The runner requires:
+/// - An RPC URL pointing to a Soroban RPC endpoint
+/// - Optional: Contract ID and network configuration
+#[derive(Debug, Clone)]
+pub struct RpcContractRunner {
+    /// The RPC endpoint URL (e.g., "https://rpc-futurenet.stellar.org:443")
+    rpc_url: String,
+    /// Optional contract ID for this runner. If set, all seeds are executed
+    /// against this contract. If unset, the contract ID is determined from seed.
+    contract_id: Option<String>,
+}
+
+impl RpcContractRunner {
+    /// Creates a new `RpcContractRunner` with the specified RPC URL.
+    ///
+    /// # Arguments
+    /// * `rpc_url` - The URL of the Soroban RPC endpoint
+    ///
+    /// # Errors
+    /// Returns [`RpcConfigError`] if:
+    /// - The URL is empty
+    /// - The URL does not start with http:// or https://
+    ///
+    /// # Examples
+    /// ```rust,no_run
+    /// # use crashlab_core::RpcContractRunner;
+    /// let runner = RpcContractRunner::new("https://rpc-futurenet.stellar.org:443");
+    /// assert!(runner.is_ok());
+    /// ```
+    pub fn new(rpc_url: impl Into<String>) -> Result<Self, RpcConfigError> {
+        let url_str = rpc_url.into();
+        
+        // Validate URL
+        if url_str.is_empty() {
+            return Err(RpcConfigError::InvalidUrl {
+                reason: "URL cannot be empty".to_string(),
+            });
+        }
+        
+        if !url_str.starts_with("http://") && !url_str.starts_with("https://") {
+            return Err(RpcConfigError::InvalidUrl {
+                reason: "URL must start with http:// or https://".to_string(),
+            });
+        }
+        
+        Ok(Self {
+            rpc_url: url_str,
+            contract_id: None,
+        })
+    }
+
+    /// Creates a new `RpcContractRunner` configured for a specific contract.
+    ///
+    /// # Arguments
+    /// * `rpc_url` - The URL of the Soroban RPC endpoint
+    /// * `contract_id` - The Soroban contract ID to target
+    ///
+    /// # Examples
+    /// ```rust,no_run
+    /// # use crashlab_core::RpcContractRunner;
+    /// let runner = RpcContractRunner::with_contract(
+    ///     "https://rpc-futurenet.stellar.org:443",
+    ///     "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    /// );
+    /// assert!(runner.is_ok());
+    /// ```
+    pub fn with_contract(
+        rpc_url: impl Into<String>,
+        contract_id: impl Into<String>,
+    ) -> Result<Self, RpcConfigError> {
+        let mut runner = Self::new(rpc_url)?;
+        runner.contract_id = Some(contract_id.into());
+        Ok(runner)
+    }
+
+    /// Returns the configured RPC URL.
+    pub fn rpc_url(&self) -> &str {
+        &self.rpc_url
+    }
+
+    /// Returns the configured contract ID, if set.
+    pub fn contract_id(&self) -> Option<&str> {
+        self.contract_id.as_deref()
+    }
+
+    /// Executes a seed against the RPC endpoint.
+    ///
+    /// This is a stub implementation that returns a placeholder signature.
+    /// Future implementations will:
+    /// 1. Parse the seed payload to determine the contract method
+    /// 2. Build an RPC transaction
+    /// 3. Send it to the RPC endpoint
+    /// 4. Capture and return the resulting signature
+    ///
+    /// Currently returns deterministic signatures based on seed content for testing.
+    fn execute_rpc(&self, seed: &CaseSeed) -> Result<CrashSignature, RunnerError> {
+        // Stub implementation: return deterministic signatures
+        // In a real implementation, this would:
+        // 1. Use self.rpc_url to connect to the endpoint
+        // 2. Build transaction payload from seed
+        // 3. Execute and capture response
+        // 4. Generate signature from result
+
+        if seed.payload.is_empty() {
+            return Ok(CrashSignature {
+                category: "rpc-empty-payload".to_string(),
+                digest: seed.id,
+                signature_hash: crate::compute_signature_hash("rpc-empty-payload", &seed.payload),
+            });
+        }
+
+        // Check for patterns that might indicate network/RPC errors
+        if seed.payload.len() == 1 && seed.payload[0] == 0xFF {
+            return Ok(CrashSignature {
+                category: "rpc-potential-timeout".to_string(),
+                digest: seed.id,
+                signature_hash: crate::compute_signature_hash("rpc-potential-timeout", &seed.payload),
+            });
+        }
+
+        // Default successful RPC execution
+        Ok(CrashSignature {
+            category: "rpc-success".to_string(),
+            digest: seed.id,
+            signature_hash: crate::compute_signature_hash("rpc-success", &seed.payload),
+        })
+    }
+}
+
+impl ContractRunner for RpcContractRunner {
+    fn run_seed(&mut self, seed: &CaseSeed) -> Result<CrashSignature, RunnerError> {
+        if self.contract_id.is_none() {
+            return Err(RunnerError::Misconfigured {
+                message: "RpcContractRunner requires a contract_id to be set".to_string(),
+            });
+        }
+
+        self.execute_rpc(seed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rpc_runner_creation_valid_url() {
+        let result = RpcContractRunner::new("https://rpc-futurenet.stellar.org:443");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rpc_runner_creation_http_url() {
+        let result = RpcContractRunner::new("http://localhost:8000");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rpc_runner_rejects_empty_url() {
+        let result = RpcContractRunner::new("");
+        assert!(result.is_err());
+        
+        if let Err(err) = result {
+            assert_eq!(
+                err,
+                RpcConfigError::InvalidUrl {
+                    reason: "URL cannot be empty".to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn rpc_runner_rejects_invalid_scheme() {
+        let result = RpcContractRunner::new("ftp://example.com");
+        assert!(result.is_err());
+        
+        if let Err(err) = result {
+            assert_eq!(
+                err,
+                RpcConfigError::InvalidUrl {
+                    reason: "URL must start with http:// or https://".to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn rpc_runner_stores_url() {
+        let url = "https://rpc-futurenet.stellar.org:443";
+        let runner = RpcContractRunner::new(url).unwrap();
+        assert_eq!(runner.rpc_url(), url);
+    }
+
+    #[test]
+    fn rpc_runner_with_contract_stores_both() {
+        let url = "https://rpc-futurenet.stellar.org:443";
+        let contract_id = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+        let runner = RpcContractRunner::with_contract(url, contract_id).unwrap();
+        
+        assert_eq!(runner.rpc_url(), url);
+        assert_eq!(runner.contract_id(), Some(contract_id));
+    }
+
+    #[test]
+    fn rpc_runner_without_contract_returns_none() {
+        let runner = RpcContractRunner::new("https://rpc-futurenet.stellar.org:443").unwrap();
+        assert_eq!(runner.contract_id(), None);
+    }
+
+    #[test]
+    fn rpc_runner_seed_execution_requires_contract_id() {
+        let mut runner = RpcContractRunner::new("https://rpc-futurenet.stellar.org:443").unwrap();
+        let seed = CaseSeed { id: 1, payload: vec![1, 2, 3] };
+
+        let result = runner.run_seed(&seed);
+        assert!(result.is_err());
+
+        if let Err(err) = result {
+            match err {
+                RunnerError::Misconfigured { message } => {
+                    assert!(message.contains("contract_id"));
+                }
+                _ => panic!("Expected Misconfigured error"),
+            }
+        }
+    }
+
+    #[test]
+    fn rpc_runner_executes_seed_with_contract_id() {
+        let mut runner = RpcContractRunner::with_contract(
+            "https://rpc-futurenet.stellar.org:443",
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        ).unwrap();
+        let seed = CaseSeed { id: 1, payload: vec![1, 2, 3] };
+
+        let sig = runner.run_seed(&seed).unwrap();
+        assert_eq!(sig.digest, 1);
+        assert_eq!(sig.category, "rpc-success");
+    }
+
+    #[test]
+    fn rpc_runner_handles_empty_payload() {
+        let mut runner = RpcContractRunner::with_contract(
+            "https://rpc-futurenet.stellar.org:443",
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        ).unwrap();
+        let seed = CaseSeed { id: 2, payload: vec![] };
+
+        let sig = runner.run_seed(&seed).unwrap();
+        assert_eq!(sig.category, "rpc-empty-payload");
+        assert_eq!(sig.digest, 2);
+    }
+
+    #[test]
+    fn rpc_runner_handles_timeout_pattern() {
+        let mut runner = RpcContractRunner::with_contract(
+            "https://rpc-futurenet.stellar.org:443",
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        ).unwrap();
+        let seed = CaseSeed { id: 3, payload: vec![0xFF] };
+
+        let sig = runner.run_seed(&seed).unwrap();
+        assert_eq!(sig.category, "rpc-potential-timeout");
+        assert_eq!(sig.digest, 3);
+    }
+
+    #[test]
+    fn rpc_config_error_display() {
+        let err = RpcConfigError::InvalidUrl {
+            reason: "URL is invalid".to_string(),
+        };
+        assert_eq!(err.to_string(), "invalid RPC URL: URL is invalid");
+    }
+
+    #[test]
+    fn rpc_runner_url_validation_is_deterministic() {
+        let url = "https://example.com/api";
+        let runner1 = RpcContractRunner::new(url).unwrap();
+        let runner2 = RpcContractRunner::new(url).unwrap();
+        
+        assert_eq!(runner1.rpc_url(), runner2.rpc_url());
+    }
+}

--- a/contracts/crashlab-core/src/runner.rs
+++ b/contracts/crashlab-core/src/runner.rs
@@ -106,6 +106,87 @@ impl ContractRunner for MockRunner {
     }
 }
 
+/// Error type for runner creation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunnerCreationError {
+    /// Invalid runner type specified in `CRASHLAB_RUNNER` environment variable.
+    InvalidRunnerType {
+        /// The invalid runner type value.
+        runner_type: String,
+    },
+    /// The requested runner type requires a feature that is not enabled.
+    FeatureNotEnabled {
+        /// Name of the required feature.
+        feature: String,
+        /// The requested runner type.
+        runner_type: String,
+    },
+}
+
+impl std::fmt::Display for RunnerCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RunnerCreationError::InvalidRunnerType { runner_type } => {
+                write!(f, "invalid runner type: '{}'. Supported types: mock, host", runner_type)
+            }
+            RunnerCreationError::FeatureNotEnabled { feature, runner_type } => {
+                write!(f, "runner type '{}' requires the '{}' feature to be enabled", runner_type, feature)
+            }
+        }
+    }
+}
+
+impl std::error::Error for RunnerCreationError {}
+
+/// Creates a [`ContractRunner`] based on the `CRASHLAB_RUNNER` environment variable.
+///
+/// # Environment Variable
+/// The `CRASHLAB_RUNNER` environment variable controls which runner implementation is used:
+/// - `"mock"` (or unset): Creates a [`MockRunner`] for testing purposes.
+/// - `"host"`: Creates a [`HostContractRunner`] for Soroban SDK testutils-based execution.
+///   This requires the `host-runner` feature to be enabled.
+///
+/// # Errors
+/// Returns [`RunnerCreationError`] if:
+/// - The `CRASHLAB_RUNNER` value is not a recognized runner type.
+/// - A requested runner type requires an unmet feature.
+///
+/// # Examples
+/// ```rust,no_run
+/// # use crashlab_core::runner::create_runner;
+/// // With CRASHLAB_RUNNER=mock (or unset):
+/// let mut runner = create_runner().expect("failed to create runner");
+///
+/// // With CRASHLAB_RUNNER=host (requires host-runner feature):
+/// # std::env::set_var("CRASHLAB_RUNNER", "host");
+/// # #[cfg(feature = "host-runner")]
+/// # let mut runner = create_runner().expect("failed to create runner");
+/// ```
+pub fn create_runner() -> Result<Box<dyn ContractRunner>, RunnerCreationError> {
+    let runner_type = std::env::var("CRASHLAB_RUNNER")
+        .unwrap_or_else(|_| "mock".to_string());
+
+    match runner_type.as_str() {
+        "mock" => Ok(Box::new(MockRunner::default())),
+        "host" => {
+            #[cfg(feature = "host-runner")]
+            {
+                Ok(Box::new(crate::host_runner::HostContractRunner::new()))
+            }
+            #[cfg(not(feature = "host-runner"))]
+            {
+                Err(RunnerCreationError::FeatureNotEnabled {
+                    feature: "host-runner".to_string(),
+                    runner_type: "host".to_string(),
+                })
+            }
+        }
+        _ => Err(RunnerCreationError::InvalidRunnerType {
+            runner_type,
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,6 +259,104 @@ mod tests {
                 message: "missing contract id".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn create_runner_defaults_to_mock_when_env_unset() {
+        // Ensure CRASHLAB_RUNNER is unset
+        std::env::remove_var("CRASHLAB_RUNNER");
+
+        let runner = create_runner();
+        assert!(runner.is_ok(), "create_runner should succeed with no env var");
+    }
+
+    #[test]
+    fn create_runner_creates_mock_when_env_is_mock() {
+        std::env::set_var("CRASHLAB_RUNNER", "mock");
+
+        let runner = create_runner();
+        assert!(runner.is_ok(), "create_runner should succeed with CRASHLAB_RUNNER=mock");
+    }
+
+    #[test]
+    fn create_runner_rejects_invalid_runner_type() {
+        std::env::set_var("CRASHLAB_RUNNER", "invalid");
+
+        let result = create_runner();
+        assert!(result.is_err(), "create_runner should fail with invalid runner type");
+        
+        if let Err(err) = result {
+            assert_eq!(
+                err,
+                RunnerCreationError::InvalidRunnerType {
+                    runner_type: "invalid".to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn create_runner_rejects_host_without_feature() {
+        std::env::set_var("CRASHLAB_RUNNER", "host");
+
+        #[cfg(not(feature = "host-runner"))]
+        {
+            let result = create_runner();
+            assert!(result.is_err(), "create_runner should fail without host-runner feature");
+            
+            if let Err(err) = result {
+                assert_eq!(
+                    err,
+                    RunnerCreationError::FeatureNotEnabled {
+                        feature: "host-runner".to_string(),
+                        runner_type: "host".to_string(),
+                    }
+                );
+            }
+        }
+
+        #[cfg(feature = "host-runner")]
+        {
+            let runner = create_runner();
+            assert!(runner.is_ok(), "create_runner should succeed with host-runner feature and CRASHLAB_RUNNER=host");
+        }
+    }
+
+    #[test]
+    fn runner_creation_error_display_invalid_type() {
+        let err = RunnerCreationError::InvalidRunnerType {
+            runner_type: "xyz".to_string(),
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "invalid runner type: 'xyz'. Supported types: mock, host"
+        );
+    }
+
+    #[test]
+    fn runner_creation_error_display_feature_not_enabled() {
+        let err = RunnerCreationError::FeatureNotEnabled {
+            feature: "host-runner".to_string(),
+            runner_type: "host".to_string(),
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "runner type 'host' requires the 'host-runner' feature to be enabled"
+        );
+    }
+
+    #[test]
+    fn mock_runner_from_factory_executes_seed() {
+        std::env::set_var("CRASHLAB_RUNNER", "mock");
+
+        let mut runner = create_runner().expect("failed to create runner");
+        let seed = CaseSeed { id: 42, payload: vec![1, 2, 3] };
+
+        let sig = runner.run_seed(&seed).expect("seed execution failed");
+        assert_eq!(sig.digest, 42);
+        assert_eq!(sig.category, "runtime-failure");
     }
 }
 


### PR DESCRIPTION
Closes #610 
## Problem
Soroban CrashLab needed a runner implementation for executing seeds against Soroban RPC 
endpoints. Previously, only local runners (MockRunner, HostContractRunner) existed, 
limiting testing capabilities for network-based contract execution.

## Solution
Implemented `RpcContractRunner`, a new runner that:
- Accepts and validates Soroban RPC endpoint URLs (http://, https://)
- Stores optional contract ID for targeted execution
- Implements the `ContractRunner` trait for consistency
- Provides clear error handling via `RpcConfigError`
- Returns deterministic signatures in stub implementation

## Implementation Details

### Configuration Options
1. **Basic initialization** with just RPC URL:
   ```rust
   let runner = RpcContractRunner::new("https://rpc-futurenet.stellar.org:443")?;
   
   