### PR TITLE
feat: persist within-column card order on the run workflow board

### DIFF
--- a/apps/web/src/app/implement-run-workflow-board-page-58.test.ts
+++ b/apps/web/src/app/implement-run-workflow-board-page-58.test.ts
@@ -233,6 +233,119 @@ function testKeyboardAccessibility() {
   console.log('  ✓ Focus management is correct');
 }
 
+// Test: Within-column reorder
+function testWithinColumnReorder() {
+  console.log("Test: Within-column reorder");
+
+  const order = ['run-001', 'run-002', 'run-003', 'run-004'];
+
+  // Drag run-004 (idx 3) and drop before run-002 (idx 1)
+  const sourceIdx = order.indexOf('run-004');
+  const targetIdx = 1; // drop before run-002
+  const adjusted = targetIdx > sourceIdx ? targetIdx - 1 : targetIdx;
+
+  const reordered = [...order];
+  const [moved] = reordered.splice(sourceIdx, 1);
+  reordered.splice(adjusted, 0, moved);
+
+  if (reordered[0] !== 'run-001') throw new Error('Expected run-001 at position 0');
+  if (reordered[1] !== 'run-004') throw new Error('Expected run-004 at position 1 (moved before run-002)');
+  if (reordered[2] !== 'run-002') throw new Error('Expected run-002 at position 2');
+  if (reordered[3] !== 'run-003') throw new Error('Expected run-003 at position 3');
+
+  console.log('  ✓ Same-column reorder inserts at correct position');
+  console.log('  ✓ Source index correctly removed before insertion');
+
+  // Drag run-001 (idx 0) and drop after run-003 (idx 3)
+  const order2 = ['run-001', 'run-002', 'run-003', 'run-004'];
+  const sourceIdx2 = order2.indexOf('run-001');
+  const targetIdx2 = 3; // drop before run-004
+  const adjusted2 = targetIdx2 > sourceIdx2 ? targetIdx2 - 1 : targetIdx2;
+
+  const reordered2 = [...order2];
+  const [moved2] = reordered2.splice(sourceIdx2, 1);
+  reordered2.splice(adjusted2, 0, moved2);
+
+  if (reordered2[0] !== 'run-002') throw new Error('Expected run-002 at position 0');
+  if (reordered2[1] !== 'run-003') throw new Error('Expected run-003 at position 1');
+  if (reordered2[2] !== 'run-001') throw new Error('Expected run-001 at position 2');
+  if (reordered2[3] !== 'run-004') throw new Error('Expected run-004 at position 3');
+
+  console.log('  ✓ Forward move (drag down) adjusted correctly');
+}
+
+// Test: Cross-column reorder with positioning
+function testCrossColumnReorder() {
+  console.log("Test: Cross-column reorder with positioning");
+
+  // Simulate column orders
+  const openOrder = ['run-001', 'run-002'];
+  const inReviewOrder = ['run-003', 'run-004'];
+
+  // Drag run-001 from open to in-review, insert before run-004 (idx 1 in inReviewOrder)
+  const fromOrder = [...openOrder];
+  const fromIdx = fromOrder.indexOf('run-001');
+  fromOrder.splice(fromIdx, 1);
+
+  const toOrder = [...inReviewOrder];
+  const insertAt = Math.min(1, toOrder.length);
+  toOrder.splice(insertAt, 0, 'run-001');
+
+  if (fromOrder.length !== 1) throw new Error('Source column should have 1 run after removal');
+  if (fromOrder[0] !== 'run-002') throw new Error('Expected run-002 remaining in open');
+  if (toOrder.length !== 3) throw new Error('Target column should have 3 runs after insertion');
+  if (toOrder[0] !== 'run-003') throw new Error('Expected run-003 at position 0');
+  if (toOrder[1] !== 'run-001') throw new Error('Expected run-001 at position 1 (inserted before run-004)');
+  if (toOrder[2] !== 'run-004') throw new Error('Expected run-004 at position 2');
+
+  console.log('  ✓ Cross-column move removes from source and inserts at target position');
+  console.log('  ✓ Source and target column orders are independently maintained');
+}
+
+// Test: Column order persistence
+function testColumnOrderPersistence() {
+  console.log("Test: Column order persistence");
+
+  localStorageMock.clear();
+
+  const savedOrder = {
+    'open': ['run-001', 'run-003', 'run-002'],
+    'in-review': ['run-004'],
+    'closed': [],
+  };
+
+  // Save
+  localStorageMock.setItem('crashlab-run-workflow-order', JSON.stringify(savedOrder));
+
+  // Load
+  const stored = localStorageMock.getItem('crashlab-run-workflow-order');
+  if (!stored) throw new Error('Failed to persist column order');
+
+  const loaded = JSON.parse(stored);
+  if (loaded['open'].length !== 3) throw new Error('Open column order length mismatch');
+  if (loaded['open'][0] !== 'run-001') throw new Error('Open order position 0 wrong');
+  if (loaded['open'][1] !== 'run-003') throw new Error('Open order position 1 wrong');
+  if (loaded['open'][2] !== 'run-002') throw new Error('Open order position 2 wrong');
+  if (loaded['in-review'].length !== 1) throw new Error('In-review column order length mismatch');
+  if (loaded['closed'].length !== 0) throw new Error('Closed column order length mismatch');
+
+  console.log('  ✓ Column order is saved to localStorage');
+  console.log('  ✓ Column order is loaded from localStorage');
+  console.log('  ✓ Order persistence survives page reload');
+
+  // Verify it doesn't interfere with workflow state storage
+  const stateData = [
+    { runId: 'run-001', workflowState: 'open' },
+  ];
+  localStorageMock.setItem('crashlab-run-workflow-states', JSON.stringify(stateData));
+  const stateStored = localStorageMock.getItem('crashlab-run-workflow-states');
+  if (!stateStored) throw new Error('Workflow state storage corrupted by order storage');
+  const stateLoaded = JSON.parse(stateStored);
+  if (stateLoaded.length !== 1) throw new Error('Workflow state length mismatch');
+
+  console.log('  ✓ Column order and workflow state use separate storage keys');
+}
+
 // Test: Run card display
 function testRunCardDisplay() {
   console.log("Test: Run card display");
@@ -270,6 +383,9 @@ function runAllTests() {
     testColumnStatistics();
     testEmptyStateHandling();
     testKeyboardAccessibility();
+    testWithinColumnReorder();
+    testCrossColumnReorder();
+    testColumnOrderPersistence();
     testRunCardDisplay();
 
     console.log('\n✅ All tests passed!');

--- a/apps/web/src/app/implement-run-workflow-board-page-58.tsx
+++ b/apps/web/src/app/implement-run-workflow-board-page-58.tsx
@@ -12,9 +12,12 @@ export interface RunWorkflowState {
   workflowState: WorkflowState;
 }
 
+export type ColumnOrder = Record<WorkflowState, string[]>;
+
 /* ── Constants ─────────────────────────────────────────────────────── */
 
 const STORAGE_KEY = 'crashlab-run-workflow-states';
+const ORDER_STORAGE_KEY = 'crashlab-run-workflow-order';
 
 const WORKFLOW_COLUMNS: { state: WorkflowState; label: string; color: string }[] = [
   { state: 'open', label: 'Open', color: 'blue' },
@@ -63,6 +66,21 @@ function saveWorkflowStates(states: Map<string, WorkflowState>) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
 
+function loadColumnOrder(): ColumnOrder {
+  if (typeof window === 'undefined') return { 'open': [], 'in-review': [], 'closed': [] };
+  try {
+    const raw = localStorage.getItem(ORDER_STORAGE_KEY);
+    if (!raw) return { 'open': [], 'in-review': [], 'closed': [] };
+    return JSON.parse(raw) as ColumnOrder;
+  } catch {
+    return { 'open': [], 'in-review': [], 'closed': [] };
+  }
+}
+
+function saveColumnOrder(order: ColumnOrder) {
+  localStorage.setItem(ORDER_STORAGE_KEY, JSON.stringify(order));
+}
+
 function getWorkflowState(
   runId: string,
   workflowStates: Map<string, WorkflowState>,
@@ -96,8 +114,10 @@ interface Props {
 
 export default function ImplementRunWorkflowBoardPage58({ runs = [] }: Props) {
   const [workflowStates, setWorkflowStates] = useState<Map<string, WorkflowState>>(new Map());
-  const [draggedRunId, setDraggedRunId] = useState<string | null>(null);
+  const [columnOrder, setColumnOrder] = useState<ColumnOrder>({ 'open': [], 'in-review': [], 'closed': [] });
+  const [dragSource, setDragSource] = useState<{ runId: string; fromColumn: WorkflowState; fromIndex: number } | null>(null);
   const [dragOverColumn, setDragOverColumn] = useState<WorkflowState | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   // Load saved workflow states on mount
   useEffect(() => {
@@ -105,17 +125,33 @@ export default function ImplementRunWorkflowBoardPage58({ runs = [] }: Props) {
     setWorkflowStates(loadWorkflowStates());
   }, []);
 
-  // Persist whenever workflow states change (skip initial empty render)
-  const mounted = useRef(false);
+  // Load saved column order on mount
   useEffect(() => {
-    if (mounted.current) {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setColumnOrder(loadColumnOrder());
+  }, []);
+
+  // Persist whenever workflow states change (skip initial empty render)
+  const stateMounted = useRef(false);
+  useEffect(() => {
+    if (stateMounted.current) {
       saveWorkflowStates(workflowStates);
     } else {
-      mounted.current = true;
+      stateMounted.current = true;
     }
   }, [workflowStates]);
 
-  // Group runs by workflow state
+  // Persist whenever column order changes (skip initial empty render)
+  const orderMounted = useRef(false);
+  useEffect(() => {
+    if (orderMounted.current) {
+      saveColumnOrder(columnOrder);
+    } else {
+      orderMounted.current = true;
+    }
+  }, [columnOrder]);
+
+  // Group runs by workflow state, respecting saved column order
   const runsByState = useMemo(() => {
     const grouped: Record<WorkflowState, FuzzingRun[]> = {
       'open': [],
@@ -123,48 +159,144 @@ export default function ImplementRunWorkflowBoardPage58({ runs = [] }: Props) {
       'closed': [],
     };
 
+    const ordered = new Set<string>();
+
+    for (const state of ['open', 'in-review', 'closed'] as WorkflowState[]) {
+      const order = columnOrder[state] || [];
+      for (const id of order) {
+        const run = runs.find((r) => r.id === id);
+        if (!run) continue;
+        const actualState = getWorkflowState(run.id, workflowStates, run.status);
+        if (actualState === state) {
+          grouped[state].push(run);
+          ordered.add(id);
+        }
+      }
+    }
+
     runs.forEach((run) => {
+      if (ordered.has(run.id)) return;
       const state = getWorkflowState(run.id, workflowStates, run.status);
       grouped[state].push(run);
     });
 
     return grouped;
-  }, [runs, workflowStates]);
+  }, [runs, workflowStates, columnOrder]);
 
   /* ── Drag-and-drop handlers ──────────────────────────────────────── */
 
-  const handleDragStart = useCallback((runId: string) => {
-    setDraggedRunId(runId);
+  const handleDragStart = useCallback((runId: string, column: WorkflowState, index: number) => {
+    setDragSource({ runId, fromColumn: column, fromIndex: index });
   }, []);
 
-  const handleDragOver = useCallback((e: React.DragEvent, column: WorkflowState) => {
+  const handleCardDragOver = useCallback((e: React.DragEvent, column: WorkflowState, index: number) => {
     e.preventDefault();
     setDragOverColumn(column);
+    setDragOverIndex(index);
+  }, []);
+
+  const handleColumnDragOver = useCallback((e: React.DragEvent, column: WorkflowState) => {
+    e.preventDefault();
+    setDragOverColumn(column);
+    setDragOverIndex(null);
   }, []);
 
   const handleDragLeave = useCallback(() => {
     setDragOverColumn(null);
+    setDragOverIndex(null);
   }, []);
 
-  const handleDrop = useCallback(
-    (targetState: WorkflowState) => {
-      if (!draggedRunId) return;
+  const handleCardDrop = useCallback(
+    (targetColumn: WorkflowState, targetIndex: number) => {
+      if (!dragSource) return;
+      const { runId, fromColumn } = dragSource;
 
-      setWorkflowStates((prev) => {
-        const next = new Map(prev);
-        next.set(draggedRunId, targetState);
+      if (fromColumn === targetColumn && dragSource.fromIndex === targetIndex) {
+        setDragSource(null);
+        setDragOverColumn(null);
+        setDragOverIndex(null);
+        return;
+      }
+
+      if (fromColumn !== targetColumn) {
+        setWorkflowStates((prev) => {
+          const next = new Map(prev);
+          next.set(runId, targetColumn);
+          return next;
+        });
+      }
+
+      setColumnOrder((prev) => {
+        const next = { ...prev };
+
+        if (fromColumn === targetColumn) {
+          const order = [...(next[fromColumn] || [])];
+          const sourceIdx = order.indexOf(runId);
+          if (sourceIdx === -1) return prev;
+          order.splice(sourceIdx, 1);
+          const adjustedTarget = targetIndex > sourceIdx ? targetIndex - 1 : targetIndex;
+          order.splice(adjustedTarget, 0, runId);
+          next[fromColumn] = order;
+        } else {
+          const fromOrder = [...(next[fromColumn] || [])];
+          const sourceIdx = fromOrder.indexOf(runId);
+          if (sourceIdx !== -1) fromOrder.splice(sourceIdx, 1);
+          next[fromColumn] = fromOrder;
+
+          const toOrder = [...(next[targetColumn] || [])];
+          const insertAt = Math.min(targetIndex, toOrder.length);
+          toOrder.splice(insertAt, 0, runId);
+          next[targetColumn] = toOrder;
+        }
+
         return next;
       });
 
-      setDraggedRunId(null);
+      setDragSource(null);
       setDragOverColumn(null);
+      setDragOverIndex(null);
     },
-    [draggedRunId]
+    [dragSource]
+  );
+
+  const handleColumnDrop = useCallback(
+    (targetState: WorkflowState) => {
+      if (!dragSource) return;
+      const { runId, fromColumn } = dragSource;
+
+      if (fromColumn !== targetState) {
+        setWorkflowStates((prev) => {
+          const next = new Map(prev);
+          next.set(runId, targetState);
+          return next;
+        });
+      }
+
+      setColumnOrder((prev) => {
+        const next = { ...prev };
+        const fromOrder = [...(next[fromColumn] || [])];
+        const idx = fromOrder.indexOf(runId);
+        if (idx !== -1) fromOrder.splice(idx, 1);
+        next[fromColumn] = fromOrder;
+
+        const toOrder = [...(next[targetState] || [])];
+        if (!toOrder.includes(runId)) toOrder.push(runId);
+        next[targetState] = toOrder;
+
+        return next;
+      });
+
+      setDragSource(null);
+      setDragOverColumn(null);
+      setDragOverIndex(null);
+    },
+    [dragSource]
   );
 
   const handleDragEnd = useCallback(() => {
-    setDraggedRunId(null);
+    setDragSource(null);
     setDragOverColumn(null);
+    setDragOverIndex(null);
   }, []);
 
   /* ── Render ──────────────────────────────────────────────────────── */
@@ -193,11 +325,11 @@ export default function ImplementRunWorkflowBoardPage58({ runs = [] }: Props) {
         {WORKFLOW_COLUMNS.map((column) => (
           <div
             key={column.state}
-            onDragOver={(e) => handleDragOver(e, column.state)}
+            onDragOver={(e) => handleColumnDragOver(e, column.state)}
             onDragLeave={handleDragLeave}
-            onDrop={() => handleDrop(column.state)}
+            onDrop={() => handleColumnDrop(column.state)}
             className={`rounded-xl border-2 transition-colors ${
-              dragOverColumn === column.state
+              dragOverColumn === column.state && dragOverIndex === null
                 ? 'border-blue-500 dark:border-blue-400 bg-blue-50/50 dark:bg-blue-950/20'
                 : COLUMN_COLORS[column.color]
             }`}
@@ -221,14 +353,20 @@ export default function ImplementRunWorkflowBoardPage58({ runs = [] }: Props) {
                   No runs
                 </div>
               ) : (
-                runsByState[column.state].map((run) => (
+                runsByState[column.state].map((run, idx) => (
                   <div
                     key={run.id}
                     draggable
-                    onDragStart={() => handleDragStart(run.id)}
+                    onDragStart={() => handleDragStart(run.id, column.state, idx)}
+                    onDragOver={(e) => handleCardDragOver(e, column.state, idx)}
+                    onDrop={() => handleCardDrop(column.state, idx)}
                     onDragEnd={handleDragEnd}
                     className={`bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-700 p-4 cursor-grab active:cursor-grabbing hover:shadow-md transition-shadow border-l-4 ${CARD_COLORS[run.status]} ${
-                      draggedRunId === run.id ? 'opacity-50' : ''
+                      dragSource?.runId === run.id ? 'opacity-50' : ''
+                    } ${
+                      dragOverIndex === idx && dragOverColumn === column.state && dragSource?.runId !== run.id
+                        ? 'ring-2 ring-blue-500 dark:ring-blue-400'
+                        : ''
                     }`}
                   >
                     <div className="flex items-start justify-between mb-2">


### PR DESCRIPTION
Add per-column order tracking (ColumnOrder state) with localStorage persistence under crashlab-run-workflow-order. Cards can now be reordered within a column via drag-and-drop, and cross-column drops insert at the exact drop position.

- Add dragSource tracking (runId + fromColumn + fromIndex)
- Add handleCardDragOver / handleCardDrop / handleColumnDrop handlers
- Update runsByState grouping to use saved column order
- Add visual feedback (blue ring) on drop target card

Closes #846