### PR TITLE
fix(web): prevent broken favicon image in issue link preview card (#851)

### DIFF
--- a/apps/web/src/app/create-run-issue-link-page-page.tsx
+++ b/apps/web/src/app/create-run-issue-link-page-page.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { useState, useCallback } from 'react';
 import { FuzzingRun, RunIssueLink } from './types';
-import { validateIssueUrl, getIssueTypeFromUrl, addIssueLink, removeIssueLink } from './run-issue-utils';
+import { validateIssueUrl, getIssueTypeFromUrl, getIssueFaviconUrl, addIssueLink, removeIssueLink } from './run-issue-utils';
 
 interface RunIssueLinkPageProps {
   runs: FuzzingRun[];
@@ -14,6 +14,56 @@ interface RunIssueLinkPageProps {
 interface IssueFormData {
   label: string;
   href: string;
+}
+
+function ExternalLinkFallbackIcon() {
+  return (
+    <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+    </svg>
+  );
+}
+
+function IssueLinkCard({ issue }: { issue: RunIssueLink }) {
+  const faviconUrl = getIssueFaviconUrl(issue.href);
+  const [faviconFailed, setFaviconFailed] = useState(false);
+
+  return (
+    <div role="listitem" className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-100">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="inline-flex items-center justify-center w-4 h-4 rounded bg-white border border-gray-200 overflow-hidden" aria-hidden="true">
+            {faviconUrl && !faviconFailed ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={faviconUrl}
+                alt=""
+                className="w-4 h-4"
+                loading="lazy"
+                referrerPolicy="no-referrer"
+                onError={() => setFaviconFailed(true)}
+              />
+            ) : (
+              <ExternalLinkFallbackIcon />
+            )}
+          </span>
+          <span className="text-xs bg-gray-200 text-gray-700 px-2 py-1 rounded">
+            {getIssueTypeFromUrl(issue.href)}
+          </span>
+        </div>
+        <div className="text-sm font-medium text-gray-900 truncate">{issue.label}</div>
+        <a
+          href={issue.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-blue-600 hover:text-blue-800 truncate block"
+          aria-label={`Open link to ${issue.label}`}
+        >
+          {issue.href}
+        </a>
+      </div>
+    </div>
+  );
 }
 
 const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
@@ -263,24 +313,8 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
                   <p className="text-sm text-gray-500 italic">No issues linked yet</p>
                 )}
                 {issueLinks.map((issue, index) => (
-                  <div key={index} role="listitem" className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-100">
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className="text-xs bg-gray-200 text-gray-700 px-2 py-1 rounded">
-                          {getIssueTypeFromUrl(issue.href)}
-                        </span>
-                      </div>
-                      <div className="text-sm font-medium text-gray-900 truncate">{issue.label}</div>
-                      <a
-                        href={issue.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs text-blue-600 hover:text-blue-800 truncate block"
-                        aria-label={`Open link to ${issue.label}`}
-                      >
-                        {issue.href}
-                      </a>
-                    </div>
+                  <div key={issue.href} className="flex items-center justify-between gap-3">
+                    <IssueLinkCard issue={issue} />
                     <button
                       onClick={() => handleRemoveIssue(index)}
                       className="ml-2 text-red-600 hover:text-red-800 p-1 rounded hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500"

--- a/apps/web/src/app/run-issue-utils.test.ts
+++ b/apps/web/src/app/run-issue-utils.test.ts
@@ -1,6 +1,13 @@
 import * as assert from 'node:assert/strict';
 import { RunIssueLink } from './types';
-import { validateIssueUrl, getIssueTypeFromUrl, addIssueLink, removeIssueLink } from './run-issue-utils';
+import {
+  validateIssueUrl,
+  getIssueTypeFromUrl,
+  getIssueHostname,
+  getIssueFaviconUrl,
+  addIssueLink,
+  removeIssueLink,
+} from './run-issue-utils';
 
 const runAssertions = () => {
   // Test validateIssueUrl
@@ -15,6 +22,15 @@ const runAssertions = () => {
   assert.equal(getIssueTypeFromUrl('https://mycompany.jira.com/issue'), 'Jira Ticket');
   assert.equal(getIssueTypeFromUrl('https://linear.app/issue'), 'Linear Issue');
   assert.equal(getIssueTypeFromUrl('https://bugtracker.com/123'), 'External Issue');
+
+  // Test hostname/favicon helpers
+  assert.equal(getIssueHostname('https://github.com/stellar/soroban-cli/issues/1'), 'github.com');
+  assert.equal(getIssueHostname('not-a-url'), null);
+  assert.equal(
+    getIssueFaviconUrl('https://github.com/stellar/soroban-cli/issues/1'),
+    'https://www.google.com/s2/favicons?domain=github.com&sz=32',
+  );
+  assert.equal(getIssueFaviconUrl('not-a-url'), null);
 
   // Test addIssueLink
   const initialLinks: RunIssueLink[] = [{ label: 'Bug 1', href: 'https://github.com/stellar/1' }];

--- a/apps/web/src/app/run-issue-utils.ts
+++ b/apps/web/src/app/run-issue-utils.ts
@@ -17,6 +17,20 @@ export function getIssueTypeFromUrl(url: string): string {
   return 'External Issue';
 }
 
+export function getIssueHostname(url: string): string | null {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
+}
+
+export function getIssueFaviconUrl(url: string): string | null {
+  const hostname = getIssueHostname(url);
+  if (!hostname) return null;
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(hostname)}&sz=32`;
+}
+
 export function addIssueLink(links: RunIssueLink[], newLink: RunIssueLink): { success: boolean; links: RunIssueLink[]; error?: string } {
   if (!validateIssueUrl(newLink.href)) {
     return { success: false, links, error: 'Invalid URL format' };


### PR DESCRIPTION
Problem:
Issue link preview cards could show a broken image state when favicon data is missing or fails to load.

Solution:
Added robust favicon handling for issue link cards by:

Adding URL helpers to derive hostname and favicon URL safely

Rendering a fallback icon when favicon URL is unavailable

Switching to fallback icon on image load failure

Adding tests for favicon helper behavior

Testing:

npm run test passed

npm run build passed

npm run lint failed due pre-existing unrelated error in [page.tsx:71](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Closes:
Closes #851