### PR TITLE
fix(web): prevent mobile stat card overflow on 320px screens (#850)

### DIFF
--- a/apps/web/src/app/analytics/calendar/page.tsx
+++ b/apps/web/src/app/analytics/calendar/page.tsx
@@ -68,7 +68,7 @@ function generateCalendarWeeks(data: DayData[], months: number = 4) {
   const weeks: CalendarCell[][] = [];
   const monthMarkers: { index: number; label: string }[] = [];
 
-  let current = new Date(startDate);
+  const current = new Date(startDate);
   let week: CalendarCell[] = [];
   let cellIndex = 0;
   let lastMonth = -1;
@@ -264,22 +264,22 @@ export default function CalendarPage() {
 
         {dataState === 'success' && (
           <>
-            <div className="mb-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
-              <div className="card card-padding">
-                <p className="stat-value text-xl">{stats.totalRuns}</p>
-                <p className="text-meta">Total runs</p>
+            <div className="mb-6 grid grid-cols-1 min-[360px]:grid-cols-2 sm:grid-cols-4 gap-3">
+              <div className="card card-padding min-w-0 overflow-hidden">
+                <p className="stat-value text-lg sm:text-xl leading-tight break-all">{stats.totalRuns}</p>
+                <p className="text-meta wrap-break-word leading-snug">Total runs</p>
               </div>
-              <div className="card card-padding">
-                <p className="stat-value text-xl">{stats.totalDays}</p>
-                <p className="text-meta">Active days</p>
+              <div className="card card-padding min-w-0 overflow-hidden">
+                <p className="stat-value text-lg sm:text-xl leading-tight break-all">{stats.totalDays}</p>
+                <p className="text-meta wrap-break-word leading-snug">Active days</p>
               </div>
-              <div className="card card-padding">
-                <p className="stat-value text-xl">{stats.totalFailed}</p>
-                <p className="text-meta">Failed runs</p>
+              <div className="card card-padding min-w-0 overflow-hidden">
+                <p className="stat-value text-lg sm:text-xl leading-tight break-all">{stats.totalFailed}</p>
+                <p className="text-meta wrap-break-word leading-snug">Failed runs</p>
               </div>
-              <div className="card card-padding">
-                <p className="stat-value text-xl">{stats.avgPerDay}</p>
-                <p className="text-meta">Avg runs / day</p>
+              <div className="card card-padding min-w-0 overflow-hidden">
+                <p className="stat-value text-lg sm:text-xl leading-tight break-all">{stats.avgPerDay}</p>
+                <p className="text-meta wrap-break-word leading-snug">Avg runs / day</p>
               </div>
             </div>
 


### PR DESCRIPTION
Problem summary:
On 320px-width devices, summary stat cards in the analytics calendar view could overflow due to a tight 2-column mobile layout combined with card padding and dynamic metric values.

Solution implemented:
Adjusted the mobile stats grid to use a single column below 360px, added overflow-safe sizing on stat cards, and applied safer wrapping/scaling classes to stat values and labels. Also fixed a prefer-const lint error in the same file.

Testing done:
Ran web verification checks locally:

npm run lint (no errors)

npm run test (pass)

npm run build (pass)

Closes:
Closes #850