### PR TITLE
fix(web): sync theme with system preference changes and unblock lint (#853)

### DIFF
--- a/apps/web/src/app/analytics/calendar/page.tsx
+++ b/apps/web/src/app/analytics/calendar/page.tsx
@@ -68,7 +68,7 @@ function generateCalendarWeeks(data: DayData[], months: number = 4) {
   const weeks: CalendarCell[][] = [];
   const monthMarkers: { index: number; label: string }[] = [];
 
-  let current = new Date(startDate);
+  const current = new Date(startDate);
   let week: CalendarCell[] = [];
   let cellIndex = 0;
   let lastMonth = -1;

--- a/apps/web/src/components/ThemeProvider.tsx
+++ b/apps/web/src/components/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState, useCallback, useSyncExternalStore } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 
 type Theme = 'light' | 'dark';
 const STORAGE_KEY = 'crashlab:theme';
@@ -17,14 +17,19 @@ const ThemeContext = createContext<ThemeContextType>({
   mounted: false,
 });
 
-function getInitialTheme(): Theme {
-  if (typeof window === 'undefined') return 'light';
+function getStoredTheme(): Theme | null {
+  if (typeof window === 'undefined') return null;
   try {
-    const saved = localStorage.getItem(STORAGE_KEY) as Theme | null;
-    if (saved === 'light' || saved === 'dark') return saved;
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
-  } catch { /* ignore */ }
-  return 'light';
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved === 'light' || saved === 'dark' ? saved : null;
+  } catch {
+    return null;
+  }
+}
+
+function getSystemPrefersDark(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 
 function subscribeToMount(cb: () => void): () => void {
@@ -47,19 +52,58 @@ export function useTheme() {
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+  const [userTheme, setUserTheme] = useState<Theme | null>(getStoredTheme);
+  const [systemPrefersDark, setSystemPrefersDark] = useState<boolean>(getSystemPrefersDark);
   const mounted = useSyncExternalStore(subscribeToMount, getMountSnapshot, getMountServerSnapshot);
 
+  const theme = useMemo<Theme>(() => {
+    if (userTheme) return userTheme;
+    return systemPrefersDark ? 'dark' : 'light';
+  }, [systemPrefersDark, userTheme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = (event: MediaQueryListEvent) => {
+      setSystemPrefersDark(event.matches);
+    };
+    mediaQuery.addEventListener('change', onChange);
+    return () => mediaQuery.removeEventListener('change', onChange);
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== STORAGE_KEY) return;
+      if (event.newValue === 'light' || event.newValue === 'dark') {
+        setUserTheme(event.newValue);
+        return;
+      }
+      setUserTheme(null);
+    };
+
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
   const toggle = useCallback(() => {
-    setTheme(prev => {
-      const next = prev === 'light' ? 'dark' : 'light';
+    setUserTheme((prev) => {
+      const base = prev ?? (systemPrefersDark ? 'dark' : 'light');
+      const next: Theme = base === 'light' ? 'dark' : 'light';
       try {
         localStorage.setItem(STORAGE_KEY, next);
-        document.documentElement.classList.toggle('dark', next === 'dark');
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
       return next;
     });
-  }, []);
+  }, [systemPrefersDark]);
 
   return (
     <ThemeContext.Provider value={{ theme, toggle, mounted }}>


### PR DESCRIPTION
Summary
This PR fixes the theme behavior so the app updates when the OS color scheme changes, and also removes the lint blocker that was failing CI.

Problem
Theme preference was only resolved at initialization, so switching system dark/light mode while the app was open did not update the UI unless the page was reloaded.

Root Cause
Theme state relied on a one-time read of system preference and did not subscribe to prefers-color-scheme change events.

Changes
Refactored theme state to support:
explicit user override from local storage
system preference fallback when no override exists
Added live subscription to prefers-color-scheme changes.
Added cross-tab synchronization via storage event handling.
Centralized application of the dark class based on effective theme.
Fixed a lint-blocking prefer-const issue in the calendar analytics page to restore CI passability.
Validation
npm run lint: passes with warnings only, no errors
npm run test: passes
npm run build: passes
Impact
Theme now stays in sync with OS preference changes in real time when no explicit user override is set.
CI no longer fails on the calendar prefer-const lint error included in this branch.
Issue

Closes #853