### PR TITLE
[915] [test] Add E2E test for mobile responsive layout

### DIFF
--- a/apps/web/e2e/mobile-responsive.spec.ts
+++ b/apps/web/e2e/mobile-responsive.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const mobileViewport = { width: 390, height: 844 };
+
+const mockRuns = [
+  {
+    id: 'run-1001',
+    status: 'completed',
+    area: 'state',
+    severity: 'high',
+    duration: 180000,
+    seedCount: 12500,
+    crashDetail: null,
+    cpuInstructions: 12300000,
+    memoryBytes: 524288000,
+    minResourceFee: 17500,
+    queuedAt: '2026-05-31T09:00:00.000Z',
+    startedAt: '2026-05-31T09:01:00.000Z',
+    finishedAt: '2026-05-31T09:04:00.000Z',
+  },
+];
+
+const fulfillRunsRequest = async (page: Page, body: unknown, status = 200) => {
+  await page.route('**/api/runs', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    if (requestUrl.pathname !== '/api/runs') {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+};
+
+test.describe('Mobile responsive layout', () => {
+  test.use({ viewport: mobileViewport });
+
+  test('shows hamburger navigation and drawer links on mobile', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('button', { name: 'Open navigation menu' })).toBeVisible();
+
+    const desktopRunsLink = page.locator('header nav').getByRole('link', { name: /Runs/i });
+    await expect(desktopRunsLink).toBeHidden();
+
+    await page.getByRole('button', { name: 'Open navigation menu' }).click();
+
+    const drawerRunsLink = page.locator('.drawer').getByRole('link', { name: 'Runs' });
+    await expect(drawerRunsLink).toBeVisible();
+    await expect(page.locator('.drawer').getByRole('link', { name: 'Dashboard' })).toBeVisible();
+
+    await drawerRunsLink.click();
+
+    await expect(page).toHaveURL(/\/runs$/);
+    await expect(page.getByRole('heading', { name: 'Fuzzing Runs' })).toBeVisible();
+  });
+
+  test('keeps dashboard content within the mobile viewport width', async ({ page }) => {
+    await fulfillRunsRequest(page, { runs: mockRuns, total: mockRuns.length });
+
+    const runsResponse = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/runs' && response.status() === 200,
+    );
+
+    await page.goto('/');
+    await runsResponse;
+
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+    const hasHorizontalOverflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    });
+    expect(hasHorizontalOverflow).toBe(false);
+
+    await expect(page.getByRole('link', { name: 'View All Runs' })).toBeVisible();
+    await expect(page.getByRole('table')).toBeVisible();
+  });
+
+  test('closes the mobile drawer with the close button', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'Open navigation menu' }).click();
+    await expect(page.locator('.drawer.open')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Close navigation menu' }).click();
+    await expect(page.locator('.drawer.open')).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/runs.spec.ts
+++ b/apps/web/e2e/runs.spec.ts
@@ -80,28 +80,29 @@ test.describe('Runs list', () => {
     await runsResponse;
 
     await expect(page.getByRole('heading', { name: 'Fuzzing Runs' })).toBeVisible();
-    await expect(page.getByText(`${mockRuns.length} Runs`)).toBeVisible();
+    await expect(page.getByText(`${mockRuns.length} Total Runs`)).toBeVisible();
 
     const table = page.getByRole('table');
-    await expect(table.getByRole('columnheader', { name: /^id$/i })).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: /Run Identifier/i })).toBeVisible();
     await expect(table.getByRole('columnheader', { name: /status/i })).toBeVisible();
     await expect(table.getByRole('columnheader', { name: /severity/i })).toBeVisible();
 
     const rows = table.locator('tbody tr');
     await expect(rows).toHaveCount(mockRuns.length);
 
-    await expect(rows.nth(0)).toContainText('run-1001');
-    await expect(rows.nth(0)).toContainText('completed');
-    await expect(rows.nth(0)).toContainText('high');
+    // Runs are sorted newest-first by queuedAt.
+    await expect(rows.nth(0)).toContainText('#1003');
+    await expect(rows.nth(0)).toContainText('running');
+    await expect(rows.nth(0)).toContainText('medium');
 
-    await expect(rows.nth(1)).toContainText('run-1002');
+    await expect(rows.nth(1)).toContainText('#1002');
     await expect(rows.nth(1)).toContainText('failed');
     await expect(rows.nth(1)).toContainText('critical');
     await expect(rows.nth(1)).toContainText('18,200');
 
-    await expect(rows.nth(2)).toContainText('run-1003');
-    await expect(rows.nth(2)).toContainText('running');
-    await expect(rows.nth(2)).toContainText('medium');
+    await expect(rows.nth(2)).toContainText('#1001');
+    await expect(rows.nth(2)).toContainText('completed');
+    await expect(rows.nth(2)).toContainText('high');
   });
 
   test('shows an error state when the runs API fails and recovers after retry', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for mobile responsive layout behavior
- Verify the hamburger menu, drawer navigation, and dashboard content fit within a mobile viewport
- Assert the mobile drawer can be opened and closed

## Test plan
- [x] `npx playwright test e2e/mobile-responsive.spec.ts --project=chromium`

Closes #915