### PR TITLE
perf: dedupe API calls, memoize stat cards, virtualize runs table, lazy-load integrations

### DIFF
--- a/apps/web/src/app/analytics/calendar/page.tsx
+++ b/apps/web/src/app/analytics/calendar/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { FuzzingRun } from '../../types';
+import { dedupedFetchJson } from '../../../lib/request-dedup';
 
 type DayData = {
   date: string;
@@ -182,8 +183,7 @@ export default function CalendarPage() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/runs')
-      .then((res) => res.json())
+    dedupedFetchJson<{ runs?: FuzzingRun[] }>('/api/runs')
       .then((data) => {
         if (!cancelled) {
           const apiRuns: FuzzingRun[] = data.runs ?? [];

--- a/apps/web/src/app/analytics/page.tsx
+++ b/apps/web/src/app/analytics/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { FuzzingRun } from '../types';
+import { dedupedFetchJson } from '../../lib/request-dedup';
 
 export default function AnalyticsPage() {
   const [runs, setRuns] = useState<FuzzingRun[]>([]);
@@ -10,8 +11,7 @@ export default function AnalyticsPage() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/runs')
-      .then((res) => res.json())
+    dedupedFetchJson<{ runs?: FuzzingRun[] }>('/api/runs')
       .then((data) => {
         if (!cancelled) {
           setRuns(data.runs ?? []);

--- a/apps/web/src/app/implement-virtualized-run-table-component.tsx
+++ b/apps/web/src/app/implement-virtualized-run-table-component.tsx
@@ -141,6 +141,19 @@ const VirtualRow = ({
                     <StatusBadge status={run.status} />
                 </td>
             )}
+            {visibleColumns.includes('area') && (
+                <td className="px-6 w-28 shrink-0 text-sm text-zinc-600 dark:text-zinc-400 truncate">
+                    {run.area}
+                </td>
+            )}
+            {visibleColumns.includes('severity') && (
+                <td
+                    className="px-6 w-28 shrink-0 text-sm truncate"
+                    style={{ color: run.severity === 'critical' ? '#C37D16' : run.severity === 'high' ? '#CC1016' : undefined }}
+                >
+                    {run.severity}
+                </td>
+            )}
             {visibleColumns.includes('duration') && (
                 <td className="px-6 w-28 shrink-0 text-sm text-zinc-600 dark:text-zinc-400 text-right tabular-nums">
                     {formatDuration(run.duration)}
@@ -283,6 +296,16 @@ export default function VirtualizedRunTable({
                             {visibleColumns.includes('status') && (
                                 <th scope="col" className="px-6 py-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100 w-36 shrink-0">
                                     Status
+                                </th>
+                            )}
+                            {visibleColumns.includes('area') && (
+                                <th scope="col" className="px-6 py-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100 w-28 shrink-0">
+                                    Area
+                                </th>
+                            )}
+                            {visibleColumns.includes('severity') && (
+                                <th scope="col" className="px-6 py-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100 w-28 shrink-0">
+                                    Severity
                                 </th>
                             )}
                             {visibleColumns.includes('duration') && (

--- a/apps/web/src/app/integrations/IntegrationPageSkeleton.tsx
+++ b/apps/web/src/app/integrations/IntegrationPageSkeleton.tsx
@@ -1,0 +1,17 @@
+/**
+ * Loading fallback shown while a heavy integration page component is being
+ * lazy-loaded via next/dynamic. Shared across all /integrations/* routes so
+ * each one doesn't redefine its own skeleton markup.
+ */
+export default function IntegrationPageSkeleton() {
+  return (
+    <div role="status" aria-label="Loading integration" className="mx-auto max-w-7xl p-4 sm:p-6 lg:p-8 animate-pulse">
+      <div className="h-8 w-64 rounded bg-zinc-200 dark:bg-zinc-800 mb-6" />
+      <div className="space-y-4">
+        <div className="h-32 rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-zinc-100 dark:bg-zinc-900" />
+        <div className="h-64 rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-950" />
+      </div>
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/integrations/api-errors/page.tsx
+++ b/apps/web/src/app/integrations/api-errors/page.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import ApiErrorReportPage from '../../api-error-report-page';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
+
+const ApiErrorReportPage = dynamic(() => import('../../api-error-report-page'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function ApiErrorsIntegrationPage() {
   return <ApiErrorReportPage />;

--- a/apps/web/src/app/integrations/artifacts/page.test.ts
+++ b/apps/web/src/app/integrations/artifacts/page.test.ts
@@ -22,8 +22,8 @@ const runAssertions = (): void => {
   const content = fs.readFileSync(componentPath, 'utf-8');
 
   assert.ok(
-    content.includes("import ArtifactStorageIntegration from '../../integrate-storage-backend-integration-for-artifacts'"),
-    'Page should import the ArtifactStorageIntegration wrapper component',
+    content.includes("dynamic(() => import('../../integrate-storage-backend-integration-for-artifacts')"),
+    'Page should lazy-load the ArtifactStorageIntegration wrapper component via next/dynamic',
   );
   assert.ok(
     content.includes('export default function ArtifactStorageIntegrationPage()'),

--- a/apps/web/src/app/integrations/artifacts/page.tsx
+++ b/apps/web/src/app/integrations/artifacts/page.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import React from 'react';
-import ArtifactStorageIntegration from '../../integrate-storage-backend-integration-for-artifacts';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
+
+const ArtifactStorageIntegration = dynamic(() => import('../../integrate-storage-backend-integration-for-artifacts'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function ArtifactStorageIntegrationPage() {
   return <ArtifactStorageIntegration />;

--- a/apps/web/src/app/integrations/auth/page.tsx
+++ b/apps/web/src/app/integrations/auth/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import React from 'react';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
 
-import ExternalAuthenticationIntegration from '../../integrate-external-authentication-integration';
+const ExternalAuthenticationIntegration = dynamic(() => import('../../integrate-external-authentication-integration'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function ExternalAuthenticationIntegrationPage() {
   return (

--- a/apps/web/src/app/integrations/ci-replay/page.tsx
+++ b/apps/web/src/app/integrations/ci-replay/page.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import React from 'react';
-import CIIntegrationForRunReplayTests from '../../integrate-ci-integration-for-run-replay-tests';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
+
+const CIIntegrationForRunReplayTests = dynamic(() => import('../../integrate-ci-integration-for-run-replay-tests'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function CIReplayIntegrationPage() {
   return (

--- a/apps/web/src/app/integrations/db-migrations/page.tsx
+++ b/apps/web/src/app/integrations/db-migrations/page.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import React from 'react';
-import DatabaseMigrationIntegrationTests from '../../integrate-database-migration-integration-tests';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
+
+const DatabaseMigrationIntegrationTests = dynamic(() => import('../../integrate-database-migration-integration-tests'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function DbMigrationsIntegrationPage() {
   return (

--- a/apps/web/src/app/integrations/issue-links/page.tsx
+++ b/apps/web/src/app/integrations/issue-links/page.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import RunIssueLinkPage from '../../create-run-issue-link-page-page';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
+
+const RunIssueLinkPage = dynamic(() => import('../../create-run-issue-link-page-page'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function IssueLinksIntegrationPage() {
   return <RunIssueLinkPage runs={[]} onLinkIssue={() => {}} />;

--- a/apps/web/src/app/integrations/prometheus/page.tsx
+++ b/apps/web/src/app/integrations/prometheus/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import React from 'react';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
 
-import MetricsExportToPrometheus from '../../integrate-metrics-export-to-prometheus';
+const MetricsExportToPrometheus = dynamic(() => import('../../integrate-metrics-export-to-prometheus'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function PrometheusPage() {
   return (

--- a/apps/web/src/app/integrations/replay-e2e/page.tsx
+++ b/apps/web/src/app/integrations/replay-e2e/page.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import ReplayEndToEndIntegrationTest from '../../integrate-replay-end-to-end-integration-test';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
+
+const ReplayEndToEndIntegrationTest = dynamic(() => import('../../integrate-replay-end-to-end-integration-test'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function ReplayE2EIntegrationPage() {
   return <ReplayEndToEndIntegrationTest />;

--- a/apps/web/src/app/integrations/sanity-check/page.tsx
+++ b/apps/web/src/app/integrations/sanity-check/page.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import SanityCheckPipelinePage from '../../create-sanity-check-pipeline-page-page';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
+
+const SanityCheckPipelinePage = dynamic(() => import('../../create-sanity-check-pipeline-page-page'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function SanityCheckIntegrationPage() {
   return <SanityCheckPipelinePage />;

--- a/apps/web/src/app/integrations/ui-harness/page.tsx
+++ b/apps/web/src/app/integrations/ui-harness/page.tsx
@@ -1,4 +1,9 @@
-import IntegrationTestHarnessForUIFlows from '../../integrate-integration-test-harness-for-ui-flows';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
+
+const IntegrationTestHarnessForUIFlows = dynamic(() => import('../../integrate-integration-test-harness-for-ui-flows'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export const metadata = {
   title: 'UI Flow Test Harness | SorobanCrashLab',

--- a/apps/web/src/app/integrations/webhooks/page.tsx
+++ b/apps/web/src/app/integrations/webhooks/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import React from 'react';
+import dynamic from 'next/dynamic';
+import IntegrationPageSkeleton from '../IntegrationPageSkeleton';
 
-import IntegrateWebhookManagerForRunEvents from '../../integrate-webhook-manager-for-run-events';
+const IntegrateWebhookManagerForRunEvents = dynamic(() => import('../../integrate-webhook-manager-for-run-events'), {
+  loading: () => <IntegrationPageSkeleton />,
+});
 
 export default function WebhooksPage() {
   return (

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AddTaggingAndLabelsUi from "./add-tagging-and-labels-ui";
 import { runMatchesTagFilter } from "./run-tags-utils";
 import { FuzzingRun } from "./types";
+import { dedupedFetchJson } from "../lib/request-dedup";
 
 const makeSuggestedLabels = (run: FuzzingRun): string[] => [
   run.area,
@@ -24,13 +25,10 @@ function DashboardContent() {
 
   useEffect(() => {
     let cancelled = false;
-    const ctrl = new AbortController();
     const load = async () => {
       setDataState("loading");
       try {
-        const res = await fetch("/api/runs", { signal: ctrl.signal });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
+        const data = await dedupedFetchJson<{ runs?: FuzzingRun[] }>("/api/runs");
         if (!cancelled) {
           setRuns(data.runs ?? []);
           setDataState("success");
@@ -42,7 +40,6 @@ function DashboardContent() {
     void load();
     return () => {
       cancelled = true;
-      ctrl.abort();
     };
   }, []);
 

--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -1,16 +1,22 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { FuzzingRun } from '../types';
 import { dedupedFetchJson } from '../../lib/request-dedup';
+import VirtualizedRunTable from '../implement-virtualized-run-table-component';
 
-const ITEMS_PER_PAGE = 10;
+const RUN_TABLE_COLUMNS = ['id', 'status', 'area', 'severity', 'duration', 'seedCount'];
 
 export default function RunsPage() {
+  const router = useRouter();
   const [dataState, setDataState] = useState<'loading' | 'success' | 'error'>('loading');
   const [runs, setRuns] = useState<FuzzingRun[]>([]);
-  const [currentPage, setCurrentPage] = useState(1);
+
+  const goToRun = useCallback((runId: string) => {
+    router.push(`/runs/${runId}`);
+  }, [router]);
 
   useEffect(() => {
     let cancelled = false;
@@ -34,10 +40,6 @@ export default function RunsPage() {
     void load();
     return () => { cancelled = true; };
   }, []);
-
-  const totalPages = Math.max(1, Math.ceil(runs.length / ITEMS_PER_PAGE));
-  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-  const paginatedRuns = runs.slice(startIndex, startIndex + ITEMS_PER_PAGE);
 
   return (
     <div className="container-full page-padding fade-in">
@@ -82,64 +84,13 @@ export default function RunsPage() {
       )}
 
       {dataState === 'success' && (
-        <div className="card table-responsive">
-          <table className="data-table">
-            <thead>
-              <tr>
-                <th>Run Identifier</th>
-                <th>Status</th>
-                <th className="hidden sm:table-cell">Area</th>
-                <th className="hidden sm:table-cell">Severity</th>
-                <th className="hidden md:table-cell">Duration</th>
-                <th className="hidden md:table-cell">Seeds</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {paginatedRuns.map((run) => (
-                <tr key={run.id}>
-                  <td className="code-text text-meta" style={{ maxWidth: '80px', overflow: 'hidden', textOverflow: 'ellipsis' }}>#{run.id.replace(/^run-/, '')}</td>
-                  <td><span className={`badge badge-${run.status}`}>{run.status}</span></td>
-                  <td className="hidden sm:table-cell">{run.area}</td>
-                  <td className="hidden sm:table-cell" style={{ color: run.severity === 'critical' ? '#C37D16' : run.severity === 'high' ? '#CC1016' : 'var(--text-primary)' }}>
-                    {run.severity}
-                  </td>
-                  <td className="hidden md:table-cell text-meta">{run.duration.toLocaleString()}ms</td>
-                  <td className="hidden md:table-cell text-meta">{run.seedCount.toLocaleString()}</td>
-                  <td>
-                    <Link href={`/runs/${run.id}`} className="link text-xs sm:text-sm whitespace-nowrap">
-                      View <span className="hidden sm:inline">Details</span> →
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {dataState === 'success' && totalPages > 1 && (
-        <div className="flex flex-col sm:flex-row items-center justify-between mt-4 gap-3">
-          <span className="text-meta text-xs sm:text-sm">Page {currentPage} of {totalPages}</span>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
-              disabled={currentPage === 1}
-              className="btn-outline text-xs sm:text-sm"
-              style={{ padding: '0 12px sm:0 16px', height: '32px sm:36px', fontSize: '13px sm:14px', opacity: currentPage === 1 ? 0.4 : 1 }}
-            >
-              ← Prev
-            </button>
-            <button
-              onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
-              disabled={currentPage === totalPages}
-              className="btn-outline text-xs sm:text-sm"
-              style={{ padding: '0 12px sm:0 16px', height: '32px sm:36px', fontSize: '13px sm:14px', opacity: currentPage === totalPages ? 0.4 : 1 }}
-            >
-              Next →
-            </button>
-          </div>
-        </div>
+        <VirtualizedRunTable
+          runs={runs}
+          viewportHeight={600}
+          visibleColumns={RUN_TABLE_COLUMNS}
+          onSelectRun={goToRun}
+          onViewReport={(run) => goToRun(run.id)}
+        />
       )}
     </div>
   );

--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { FuzzingRun } from '../types';
+import { dedupedFetchJson } from '../../lib/request-dedup';
 
 const ITEMS_PER_PAGE = 10;
 
@@ -16,9 +17,7 @@ export default function RunsPage() {
     const load = async () => {
       setDataState('loading');
       try {
-        const res = await fetch('/api/runs');
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
+        const data = await dedupedFetchJson<{ runs?: FuzzingRun[] }>('/api/runs');
         if (!cancelled) {
           const sorted = (data.runs ?? []).slice().sort((a: FuzzingRun, b: FuzzingRun) => {
             const ta = a.queuedAt ?? a.startedAt ?? '';

--- a/apps/web/src/app/runs/query/page.tsx
+++ b/apps/web/src/app/runs/query/page.tsx
@@ -3,12 +3,11 @@
 import { useEffect, useState } from 'react';
 import type { FuzzingRun } from '../../types';
 import AddAFuzzyQueryBuilderPage51 from '../../add-a-fuzzy-query-builder-page-51';
+import { dedupedFetchJson } from '../../../lib/request-dedup';
 
 async function fetchRuns(): Promise<FuzzingRun[]> {
-  const res = await fetch('/api/runs');
-  if (!res.ok) throw new Error('Failed to fetch runs');
-  const data = await res.json();
-  return data.runs as FuzzingRun[];
+  const data = await dedupedFetchJson<{ runs?: FuzzingRun[] }>('/api/runs');
+  return data.runs ?? [];
 }
 
 type PageDataState = 'loading' | 'success' | 'error';

--- a/apps/web/src/app/trends/page.tsx
+++ b/apps/web/src/app/trends/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { FuzzingRun, RunArea, RunSeverity } from '../types';
 import { FilterBar } from './FilterBar';
@@ -83,6 +83,8 @@ export default function CrashTrendPage() {
 
   const isEmpty = isChartDataEmpty(chartData);
   const hasNoRuns = runs.length === 0;
+
+  const totalCrashes = useMemo(() => calculateTotalCrashes(chartData), [chartData]);
 
   return (
     <div className="min-h-screen bg-white dark:bg-zinc-950">
@@ -170,7 +172,7 @@ export default function CrashTrendPage() {
                   />
                   <StatCard
                     label="Total Crashes"
-                    value={calculateTotalCrashes(chartData).toString()}
+                    value={totalCrashes.toString()}
                   />
                 </div>
               </div>
@@ -184,8 +186,12 @@ export default function CrashTrendPage() {
 
 /**
  * Display helper: statistics card for summary metrics.
+ *
+ * Memoized so a parent re-render (e.g. a filter change that only affects
+ * one of the four cards) doesn't force the other, unchanged cards to
+ * re-render as well.
  */
-function StatCard({ label, value }: { label: string; value: string }) {
+const StatCard = memo(function StatCard({ label, value }: { label: string; value: string }) {
   return (
     <div className="p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
       <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wide">
@@ -196,7 +202,7 @@ function StatCard({ label, value }: { label: string; value: string }) {
       </p>
     </div>
   );
-}
+});
 
 /**
  * Calculate total crashes across all chart data points.

--- a/apps/web/src/app/trends/page.tsx
+++ b/apps/web/src/app/trends/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { FuzzingRun, RunArea, RunSeverity } from '../types';
 import { FilterBar } from './FilterBar';
 import { CrashTrendChart } from './CrashTrendChart';
+import { dedupedFetchJson } from '../../lib/request-dedup';
 import {
   transformRunsToCrashEvents,
   bucketByDay,
@@ -24,9 +25,8 @@ export default function CrashTrendPage() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/runs')
-      .then((res) => res.json())
-      .then((data) => { if (!cancelled) setRuns(data.runs); })
+    dedupedFetchJson<{ runs?: FuzzingRun[] }>('/api/runs')
+      .then((data) => { if (!cancelled) setRuns(data.runs ?? []); })
       .catch(() => {});
     return () => { cancelled = true; };
   }, []);

--- a/apps/web/src/app/triage/board/page.tsx
+++ b/apps/web/src/app/triage/board/page.tsx
@@ -3,12 +3,11 @@
 import { useEffect, useState } from 'react';
 import type { FuzzingRun } from '../../types';
 import ImplementRunWorkflowBoardPage58 from '../../implement-run-workflow-board-page-58';
+import { dedupedFetchJson } from '../../../lib/request-dedup';
 
 async function fetchRuns(): Promise<FuzzingRun[]> {
-  const res = await fetch('/api/runs');
-  if (!res.ok) throw new Error('Failed to fetch runs');
-  const data = await res.json();
-  return data.runs as FuzzingRun[];
+  const data = await dedupedFetchJson<{ runs?: FuzzingRun[] }>('/api/runs');
+  return data.runs ?? [];
 }
 
 type PageDataState = 'loading' | 'success' | 'error';

--- a/apps/web/src/app/triage/page.tsx
+++ b/apps/web/src/app/triage/page.tsx
@@ -11,6 +11,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { FuzzingRun, RunIssueLink } from "../types";
+import { dedupedFetchJson } from "../../lib/request-dedup";
 import {
   TRIAGE_COLUMNS,
   getColumnRuns,
@@ -24,10 +25,8 @@ import {
 // ---------------------------------------------------------------------------
 
 async function fetchRuns(): Promise<FuzzingRun[]> {
-  const res = await fetch('/api/runs');
-  if (!res.ok) throw new Error('Failed to fetch runs');
-  const data = await res.json();
-  return data.runs as FuzzingRun[];
+  const data = await dedupedFetchJson<{ runs?: FuzzingRun[] }>('/api/runs');
+  return data.runs ?? [];
 }
 
 async function fetchIssuesForRuns(

--- a/apps/web/src/lib/request-dedup.ts
+++ b/apps/web/src/lib/request-dedup.ts
@@ -1,0 +1,28 @@
+/**
+ * Coalesces concurrent GET requests to the same URL into a single network
+ * call. Several routes (dashboard, runs list, trends, triage, analytics)
+ * independently fetch `/api/runs` on mount, which previously produced
+ * duplicate in-flight requests whenever more than one of them rendered at
+ * the same time. Callers awaiting the same URL while a request is already
+ * in flight share that request's parsed JSON result instead of issuing a
+ * new fetch.
+ */
+
+const inFlightRequests = new Map<string, Promise<unknown>>();
+
+export function dedupedFetchJson<T>(url: string): Promise<T> {
+  const existing = inFlightRequests.get(url);
+  if (existing) return existing as Promise<T>;
+
+  const request = fetch(url)
+    .then((res) => {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.json() as Promise<T>;
+    })
+    .finally(() => {
+      inFlightRequests.delete(url);
+    });
+
+  inFlightRequests.set(url, request);
+  return request;
+}


### PR DESCRIPTION
## Summary

Four scoped frontend performance fixes, bundled together since they touch independent areas of `apps/web`:

- **Request deduplication** — Several routes (dashboard, runs list, trends, triage, triage board, runs query, analytics, analytics calendar) each independently called `fetch('/api/runs')` on mount with no coordination. Added `dedupedFetchJson` in `apps/web/src/lib/request-dedup.ts`, which coalesces concurrent requests to the same URL into a single network call, and switched all of those call sites to use it.
- **Dashboard stat card re-renders** — `StatCard` on the crash trends dashboard re-rendered on every page re-render even when its own label/value hadn't changed. Wrapped it in `React.memo` and memoized the total-crashes calculation with `useMemo`.
- **Virtual scrolling for the runs table** — `/runs` rendered the full filtered run list into the DOM and paginated it client-side. Wired in the existing `VirtualizedRunTable` component (previously built but never used by any route) so only rows near the viewport are mounted, and extended it with `area`/`severity` columns to preserve what the page showed before.
- **Lazy loading for integration pages** — Every `/integrations/*` route statically imported its (often large) feature component. Converted each sub-page to load its component via `next/dynamic` with a shared `IntegrationPageSkeleton` fallback, so a given integration's code is only fetched when its page is visited.

Closes #923
Closes #922
Closes #920
Closes #921

## Checklist

- [x] Branch name follows `issue/<number>-<slug>` convention (multi-issue branch, named for the bundled scope)
- [x] Scope limited to the files relevant to these four issues
- [x] Updated the existing `artifacts/page.test.ts` assertion to match the new dynamic-import pattern
- [x] `pnpm-lock.yaml` / `package-lock.json` **not** modified
- [x] `package.json` unchanged — no maintainer approval needed

## Test plan

- [ ] Open the dashboard, `/runs`, `/trends`, `/triage`, `/triage/board`, `/runs/query`, `/analytics`, `/analytics/calendar` and confirm each still loads run data correctly, and that the Network tab shows no duplicate concurrent `GET /api/runs` requests
- [ ] On `/trends`, change filters and confirm the four summary stat cards still update correctly
- [ ] Open `/runs` with a larger run list and confirm rows scroll smoothly with a bounded DOM node count (virtualized), and that Area/Severity/Duration/Seed Count columns still display
- [ ] Visit each `/integrations/*` sub-page and confirm it still renders correctly, briefly showing the loading skeleton on first load of that route's chunk