### PR TITLE
ci(workflows): configure stale issue workflow (ROADMAP-135)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,40 @@
+name: Stale issue and PR management
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 7 days if no further
+            activity occurs. Thank you for your contributions.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 7 days if no
+            further activity occurs. Thank you for your contributions.
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity. Please
+            feel free to reopen if needed.
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity.
+            Please feel free to reopen if needed.
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security,backlog
+          exempt-pr-labels: pinned,security,dependencies
+          operations-per-run: 100
+          remove-stale-when-updated: true


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to automatically manage stale issues and pull requests. Inactive items are marked stale after 60 days and closed after 7 more days of inactivity.

Closes #722

## Changes

- `.github/workflows/stale.yml` — new workflow using `actions/stale@v9`

## Configuration

- **Schedule**: Daily at 1:30 AM UTC + manual trigger via `workflow_dispatch`
- **Stale threshold**: 60 days without activity
- **Close threshold**: 7 days after stale label applied
- **Labels**: Marks with `stale` label
- **Exempt labels**:
  - Issues: `pinned`, `security`, `backlog`
  - PRs: `pinned`, `security`, `dependencies`
- **Behavior**: Removes `stale` label on new activity; max 100 operations per run

## Checklist

- [x] Branch name follows `issue/<number>-<slug>`
- [x] Scope limited to files listed in the issue
- [ ] Tests added or updated — N/A (workflow configuration only)
- [x] `pnpm-lock.yaml` / `package-lock.json` **not** modified
- [ ] `package.json` unchanged

## Test plan

- YAML syntax follows the conventions of the 3 existing workflows in `.github/workflows/`
- CI will validate the workflow when merged to main