### PR TITLE
Add aria-label attributes to icon-only buttons that were missing them

### DIFF
--- a/apps/web/src/app/TimelineScrubber.tsx
+++ b/apps/web/src/app/TimelineScrubber.tsx
@@ -119,8 +119,9 @@ export default function TimelineScrubber({
               disabled={index <= 0}
               className="p-2 rounded-lg hover:bg-white dark:hover:bg-zinc-800 disabled:opacity-30 transition-all active:scale-90"
               title="Previous Run"
+              aria-label="Previous run"
             >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
               </svg>
             </button>
@@ -129,8 +130,9 @@ export default function TimelineScrubber({
               disabled={index >= runs.length - 1}
               className="p-2 rounded-lg hover:bg-white dark:hover:bg-zinc-800 disabled:opacity-30 transition-all active:scale-90"
               title="Next Run"
+              aria-label="Next run"
             >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
             </button>

--- a/apps/web/src/app/add-run-cluster-visualization.tsx
+++ b/apps/web/src/app/add-run-cluster-visualization.tsx
@@ -1096,12 +1096,14 @@ const ClusterDetails: React.FC<{
         <button
           onClick={onClose}
           className="p-2 text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
+          aria-label="Close cluster detail"
         >
           <svg
             className="w-5 h-5"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
             <path
               strokeLinecap="round"

--- a/apps/web/src/app/dashboard/DashboardShell.tsx
+++ b/apps/web/src/app/dashboard/DashboardShell.tsx
@@ -206,6 +206,7 @@ export default function DashboardShell({
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
             </svg>
@@ -227,7 +228,7 @@ export default function DashboardShell({
               className="md:hidden p-2 rounded-xl text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800/50"
               aria-label="Toggle mobile menu"
             >
-              <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={isMobileMenuOpen ? "M6 18L18 6M6 6l12 12" : "M4 6h16M4 12h16M4 18h16"} />
               </svg>
             </button>
@@ -296,8 +297,9 @@ export default function DashboardShell({
                   type="button"
                   onClick={() => setIsMobileMenuOpen(false)}
                   className="p-2 rounded-xl text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800/50"
+                  aria-label="Close mobile menu"
                 >
-                  <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </button>


### PR DESCRIPTION
## Summary

Add `aria-label` attributes to icon-only buttons that were missing them, and mark their decorative SVGs with `aria-hidden="true"`.

Closes #928

### Changes

- `TimelineScrubber.tsx`: Add `aria-label="Previous run"` / `"Next run"` to prev/next navigation buttons
- `DashboardShell.tsx`: Add `aria-label="Close mobile menu"` to the mobile drawer close button; add `aria-hidden="true"` to SVGs in sidebar collapse and mobile menu toggle buttons
- `add-run-cluster-visualization.tsx`: Add `aria-label="Close cluster detail"` to the cluster detail close button

## Checklist

- [x] Branch name follows `issue/<number>-<slug>`
- [x] Scope limited to files listed in the issue
- [ ] Tests added or updated
- [x] `pnpm-lock.yaml` / `package-lock.json` **not** modified

## Test plan

1. Navigate to the Timeline Scrubber and verify the Previous/Next buttons are announced by screen readers
2. Open the mobile menu in the Dashboard and verify the close button is announced
3. Open a cluster detail view and verify the close button is announced
4. Verify decorative SVGs are hidden from assistive technology