### PR TITLE
Add visible `:focus-visible` indicators for all interactive elements

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,6 +2,21 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/*
+ * Global focus-visible indicator for all interactive elements.
+ * Provides a consistent 2px blue ring so keyboard users always
+ * know which element is focused.  Uses :focus-visible so the
+ * ring only appears on keyboard navigation, not on clicks.
+ */
+:where(a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])):focus-visible {
+  outline: 2px solid #0A66C2;
+  outline-offset: 2px;
+}
+
+.dark :where(a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])):focus-visible {
+  outline-color: #5AA7F0;
+}
+
 @theme {
   --color-primary: #0A66C2;
   --color-primary-hover: #004182;
@@ -187,6 +202,12 @@ body {
   background: #004182;
 }
 
+.btn-primary:focus-visible {
+  outline: 2px solid #004182;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(10, 102, 194, 0.2);
+}
+
 .btn-primary:disabled {
   opacity: 0.4;
   cursor: not-allowed;
@@ -214,6 +235,12 @@ body {
   background: rgba(10, 102, 194, 0.05);
 }
 
+.btn-outline:focus-visible {
+  outline: 2px solid #0A66C2;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(10, 102, 194, 0.2);
+}
+
 .btn-ghost {
   display: inline-flex;
   align-items: center;
@@ -234,6 +261,12 @@ body {
 
 .btn-ghost:hover {
   background: rgba(10, 102, 194, 0.05);
+}
+
+.btn-ghost:focus-visible {
+  outline: 2px solid #0A66C2;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(10, 102, 194, 0.2);
 }
 
 .input-field {


### PR DESCRIPTION
## Summary

Add visible `:focus-visible` indicators for all interactive elements so keyboard users always see which element is focused.

Closes #930

### Changes in `globals.css`

- **Global rule**: `:where(a, button, input, select, textarea, [tabindex])` gets a `2px solid #0A66C2` outline on `:focus-visible`, with `outline-offset: 2px`
- **Dark mode variant**: `.dark` context overrides outline to `#5AA7F0` for visibility against dark backgrounds
- **Button classes**: `.btn-primary`, `.btn-outline`, `.btn-ghost` each get `:focus-visible` with outline + `box-shadow: 0 0 0 4px rgba(10, 102, 194, 0.2)` for enhanced visibility
- Uses `:focus-visible` (not `:focus`) so the ring only appears on keyboard navigation, not mouse clicks

## Checklist

- [x] Branch name follows `issue/<number>-<slug>`
- [x] Scope limited to files listed in the issue
- [ ] Tests added or updated
- [x] `pnpm-lock.yaml` / `package-lock.json` **not** modified

## Test plan

1. Tab through the app and verify every interactive element (buttons, links, inputs, table rows) shows a visible blue outline
2. Verify outline is lighter blue in dark mode
3. Verify mouse clicks do not trigger the focus ring (`:focus-visible` behavior)
4. Verify `.btn-primary`, `.btn-outline`, `.btn-ghost` show enhanced ring with box-shadow