### PR TITLE
Ensures all text and UI components meet WCAG AA contrast requirements

### DIFF
--- a/apps/web/src/app/TimelineScrubber.tsx
+++ b/apps/web/src/app/TimelineScrubber.tsx
@@ -119,8 +119,9 @@ export default function TimelineScrubber({
               disabled={index <= 0}
               className="p-2 rounded-lg hover:bg-white dark:hover:bg-zinc-800 disabled:opacity-30 transition-all active:scale-90"
               title="Previous Run"
+              aria-label="Previous run"
             >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
               </svg>
             </button>
@@ -129,8 +130,9 @@ export default function TimelineScrubber({
               disabled={index >= runs.length - 1}
               className="p-2 rounded-lg hover:bg-white dark:hover:bg-zinc-800 disabled:opacity-30 transition-all active:scale-90"
               title="Next Run"
+              aria-label="Next run"
             >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
             </button>

--- a/apps/web/src/app/TimelineScrubber.tsx
+++ b/apps/web/src/app/TimelineScrubber.tsx
@@ -189,7 +189,7 @@ export default function TimelineScrubber({
                 className={`flex flex-col items-center transition-all duration-300 ${isSelected ? 'scale-110' : 'scale-100 opacity-40'}`}
               >
                 <div className={`w-1 h-2 rounded-full mb-2 ${isSelected ? 'bg-blue-600' : 'bg-zinc-300 dark:bg-zinc-700'}`} />
-                <span className={`text-[9px] font-bold tracking-tighter ${isSelected ? 'text-blue-600 dark:text-blue-400' : 'text-zinc-400'}`}>
+                <span className={`text-[9px] font-bold tracking-tighter ${isSelected ? 'text-blue-600 dark:text-blue-400' : 'text-zinc-500 dark:text-zinc-400'}`}>
                   {isEndpoint || isSelected ? run.id.slice(-4) : ''}
                 </span>
               </div>
@@ -200,25 +200,25 @@ export default function TimelineScrubber({
 
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 sm:gap-6 p-3 sm:p-5 bg-zinc-50/50 dark:bg-zinc-900/30 rounded-2xl border border-zinc-200 dark:border-zinc-800/50 backdrop-blur-sm">
         <div className="space-y-1">
-          <div className="text-[10px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest">Status</div>
+          <div className="text-[10px] font-bold text-zinc-500 dark:text-zinc-400 uppercase tracking-widest">Status</div>
           <div className="flex items-center gap-2">
              <StatusBadge status={currentRun.status} />
           </div>
         </div>
         <div className="space-y-1">
-          <div className="text-[10px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest">Product Area</div>
+          <div className="text-[10px] font-bold text-zinc-500 dark:text-zinc-400 uppercase tracking-widest">Product Area</div>
           <div className="text-sm font-bold text-zinc-800 dark:text-zinc-200 capitalize">{currentRun.area}</div>
         </div>
         <div className="space-y-1">
-          <div className="text-[10px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest">Risk Level</div>
+          <div className="text-[10px] font-bold text-zinc-500 dark:text-zinc-400 uppercase tracking-widest">Risk Level</div>
           <div className="flex items-center gap-2">
             <SeverityBadge severity={currentRun.severity} />
           </div>
         </div>
         <div className="space-y-1">
-          <div className="text-[10px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest">Seeds / Instructions</div>
+          <div className="text-[10px] font-bold text-zinc-500 dark:text-zinc-400 uppercase tracking-widest">Seeds / Instructions</div>
           <div className="text-sm font-bold text-zinc-800 dark:text-zinc-200">
-            {currentRun.seedCount.toLocaleString()} <span className="text-zinc-400 font-normal">/</span> {(currentRun.cpuInstructions / 1_000_000).toFixed(1)}M
+            {currentRun.seedCount.toLocaleString()} <span className="text-zinc-500 dark:text-zinc-400 font-normal">/</span> {(currentRun.cpuInstructions / 1_000_000).toFixed(1)}M
           </div>
         </div>
       </div>

--- a/apps/web/src/app/add-run-cluster-visualization.tsx
+++ b/apps/web/src/app/add-run-cluster-visualization.tsx
@@ -1096,12 +1096,14 @@ const ClusterDetails: React.FC<{
         <button
           onClick={onClose}
           className="p-2 text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
+          aria-label="Close cluster detail"
         >
           <svg
             className="w-5 h-5"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
             <path
               strokeLinecap="round"

--- a/apps/web/src/app/add-run-cluster-visualization.tsx
+++ b/apps/web/src/app/add-run-cluster-visualization.tsx
@@ -288,7 +288,7 @@ const RunClusterVisualization: React.FC<RunClusterVisualizationProps> = ({
           <p className="text-zinc-500 dark:text-zinc-400 font-medium">
             No cluster data available.
           </p>
-          <p className="text-sm text-zinc-400 dark:text-zinc-500 mt-1">
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">
             Start a new campaign to see cluster visualization.
           </p>
         </div>

--- a/apps/web/src/app/dashboard/DashboardShell.tsx
+++ b/apps/web/src/app/dashboard/DashboardShell.tsx
@@ -153,7 +153,7 @@ export default function DashboardShell({
                 }`}
                 title={isSidebarCollapsed ? item.name : undefined}
               >
-                <span className={`shrink-0 ${isActive ? "text-blue-600 dark:text-blue-400" : "text-zinc-400 group-hover:text-zinc-600 dark:group-hover:text-zinc-300"}`}>
+                <span className={`shrink-0 ${isActive ? "text-blue-600 dark:text-blue-400" : "text-zinc-500 dark:text-zinc-400 group-hover:text-zinc-600 dark:group-hover:text-zinc-300"}`}>
                   {item.icon}
                 </span>
                 {!isSidebarCollapsed && <span className="truncate">{item.name}</span>}
@@ -173,7 +173,7 @@ export default function DashboardShell({
               className="flex items-center gap-3 px-3 py-2 rounded-lg text-xs font-medium text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors group"
               title={isSidebarCollapsed ? item.name : undefined}
             >
-              <span className="shrink-0 text-zinc-400 group-hover:text-zinc-600 dark:group-hover:text-zinc-300">
+              <span className="shrink-0 text-zinc-500 dark:text-zinc-400 group-hover:text-zinc-600 dark:group-hover:text-zinc-300">
                 {item.icon}
               </span>
               {!isSidebarCollapsed && <span className="truncate">{item.name}</span>}
@@ -198,7 +198,7 @@ export default function DashboardShell({
           <button
             type="button"
             onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
-            className="w-full flex items-center justify-center p-2 rounded-xl text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 transition-all border border-zinc-200/40 dark:border-zinc-800/40"
+            className="w-full flex items-center justify-center p-2 rounded-xl text-zinc-500 dark:text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 transition-all border border-zinc-200/40 dark:border-zinc-800/40"
             aria-label={isSidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           >
             <svg
@@ -234,7 +234,7 @@ export default function DashboardShell({
             </button>
 
             {/* Breadcrumbs */}
-            <div className="hidden sm:flex items-center gap-2 text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+            <div className="hidden sm:flex items-center gap-2 text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
               <span>CrashLab</span>
               <svg className="h-3 w-3 text-zinc-300 dark:text-zinc-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -246,7 +246,7 @@ export default function DashboardShell({
           {/* Header Action Elements */}
           <div className="flex items-center gap-4">
             {/* Search Shortcut */}
-            <div className="hidden md:flex items-center gap-2 px-3 py-1.5 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-950 text-xs text-zinc-400">
+            <div className="hidden md:flex items-center gap-2 px-3 py-1.5 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-950 text-xs text-zinc-500 dark:text-zinc-400">
               <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
               </svg>
@@ -265,7 +265,7 @@ export default function DashboardShell({
                     : "bg-zinc-100 text-zinc-600 border-zinc-200/50 dark:bg-zinc-800 dark:text-zinc-400 dark:border-zinc-700/50"
                 }`}
               >
-                <span className={`h-1.5 w-1.5 rounded-full ${isMaintainer ? "bg-amber-500 animate-pulse" : "bg-zinc-400"}`} />
+                <span className={`h-1.5 w-1.5 rounded-full ${isMaintainer ? "bg-amber-500 animate-pulse" : "bg-zinc-500 dark:bg-zinc-400"}`} />
                 <span>{isMaintainer ? "Maintainer" : "User"} Mode</span>
               </button>
             </div>
@@ -296,7 +296,7 @@ export default function DashboardShell({
                 <button
                   type="button"
                   onClick={() => setIsMobileMenuOpen(false)}
-                  className="p-2 rounded-xl text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800/50"
+                  className="p-2 rounded-xl text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800/50"
                   aria-label="Close mobile menu"
                 >
                   <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -372,7 +372,7 @@ export default function DashboardShell({
             {/* Dashboard Layout Footer */}
             <footer className="border-t border-zinc-200/50 dark:border-zinc-800/50 pt-8 mt-12 text-center text-xs text-zinc-500 leading-normal">
               <p>Soroban CrashLab &middot; Stellar &amp; Soroban smart contract invariant mutation framework</p>
-              <p className="mt-1 text-zinc-400 dark:text-zinc-600">Continuous fuzzing node &middot; Version 0.1.0 (Stellar Wave 3 Release)</p>
+              <p className="mt-1 text-zinc-500 dark:text-zinc-400">Continuous fuzzing node &middot; Version 0.1.0 (Stellar Wave 3 Release)</p>
             </footer>
 
           </div>

--- a/apps/web/src/app/dashboard/DashboardShell.tsx
+++ b/apps/web/src/app/dashboard/DashboardShell.tsx
@@ -206,6 +206,7 @@ export default function DashboardShell({
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
             </svg>
@@ -227,7 +228,7 @@ export default function DashboardShell({
               className="md:hidden p-2 rounded-xl text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800/50"
               aria-label="Toggle mobile menu"
             >
-              <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={isMobileMenuOpen ? "M6 18L18 6M6 6l12 12" : "M4 6h16M4 12h16M4 18h16"} />
               </svg>
             </button>
@@ -296,8 +297,9 @@ export default function DashboardShell({
                   type="button"
                   onClick={() => setIsMobileMenuOpen(false)}
                   className="p-2 rounded-xl text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800/50"
+                  aria-label="Close mobile menu"
                 >
-                  <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </button>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -13,7 +13,7 @@
   --color-text-secondary: #666666;
   --color-border: #E0DFDC;
   --color-success: #057642;
-  --color-warning: #C37D16;
+  --color-warning: #946210;
   --color-error: #CC1016;
 }
 
@@ -45,7 +45,7 @@
   --card-shadow: 0 0 0 1px rgba(255, 255, 255, 0.04), 0 2px 4px rgba(0, 0, 0, 0.3);
   --card-shadow-hover: 0 0 0 1px rgba(0, 255, 65, 0.08), 0 4px 12px rgba(0, 0, 0, 0.4);
   --input-bg: #0a0a0a;
-  --input-border: #2a2a2a;
+  --input-border: #606060;
   --skeleton-from: #1a1a1a;
   --skeleton-to: #111111;
   --chip-bg: #1a1a1a;
@@ -302,7 +302,15 @@ body {
 
 .badge-critical {
   background: rgba(195, 125, 22, 0.1);
-  color: #C37D16;
+  color: #946210;
+}
+
+.dark .badge-completed {
+  color: #229B6B;
+}
+
+.dark .badge-failed {
+  color: #EF4444;
 }
 
 .link {


### PR DESCRIPTION
## Summary

Ensures all text and UI components meet WCAG AA contrast requirements (4.5:1 for normal text, 3:1 for large text and UI components).

Closes #929

### Changes

**globals.css — badge & input contrast:**
- `--color-warning`: `#C37D16` → `#946210` (4.7:1 on badge bg, was 3.01:1)
- Dark mode `--input-border`: `#2a2a2a` → `#606060` (3.15:1, was 1.38:1)
- `.badge-critical` color updated to match new warning token
- Added `.dark .badge-completed { color: #229B6B }` (5.03:1, was 3.10:1)
- Added `.dark .badge-failed { color: #EF4444 }` (4.84:1, was 3.17:1)

**Component text color fixes (`text-zinc-400` → `text-zinc-500`):**
- `TimelineScrubber.tsx`: Fixed 6 instances — run labels, stat headings, separator
- `DashboardShell.tsx`: Fixed 8 instances — sidebar icons, breadcrumbs, search, footer
- `add-run-cluster-visualization.tsx`: Swapped reversed `text-zinc-400 dark:text-zinc-500` pattern

All swapped from `text-zinc-400` (2.56:1 on white) to `text-zinc-500` (4.83:1 on white).

## Checklist

- [x] Branch name follows `issue/<number>-<slug>`
- [x] Scope limited to files listed in the issue
- [ ] Tests added or updated
- [x] `pnpm-lock.yaml` / `package-lock.json` **not** modified
- [x] If `package.json` changed: maintainer approval requested below

## Test plan

1. Verify badge text contrast with a WCAG contrast checker tool against their backgrounds
2. Check `text-zinc-500` renders with ≥4.5:1 ratio on both light (#F4F2EE / #FFFFFF) and dark backgrounds
3. Confirm dark mode input field borders are visible (3:1 against #0a0a0a)
4. Visually inspect badge-completed, badge-failed in dark mode for readability