### PR TITLE
ci(ci): migrate CI from npm to pnpm (ROADMAP-132)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,18 @@ jobs:
         working-directory: apps/web
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: apps/web/package-lock.json
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run test
-      - run: npm run build
+          cache: pnpm
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
+      - run: pnpm run test
+      - run: pnpm run build
 
   core:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -67,14 +70,17 @@ jobs:
         working-directory: apps/web
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: apps/web/package-lock.json
-      - run: npm ci
-      - run: npx playwright install --with-deps chromium
-      - run: npx playwright test
+          cache: pnpm
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm dlx playwright install --with-deps chromium
+      - run: pnpm dlx playwright test
 
   regression:
     needs: [core, web, soroban-example]


### PR DESCRIPTION
Migrates CI workflow from npm to pnpm.

Changes:
- Added `pnpm/action-setup@v4` step before `setup-node` in the `web` and `e2e` jobs
- Updated `actions/setup-node` cache from `npm` to `pnpm`
- Changed cache dependency path to `pnpm-lock.yaml`
- Replaced `npm ci` with `pnpm install --frozen-lockfile`
- Replaced `npm run` with `pnpm run`
- Replaced `npx` with `pnpm dlx`

Closes: #719