### PR TITLE
Added input sanitization for search queries and forms having a proper…

### DIFF
--- a/apps/web/src/app/api/runs/route.ts
+++ b/apps/web/src/app/api/runs/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { errorResponse, successResponse, status } from '@/lib/api-response-utils';
 import { logger } from '@/lib/logger';
 import { withRouteErrorHandling } from '@/lib/route-handler';
+import { sanitizeSearchParams } from '@/lib/sanitize';
 
 export const GET = withRouteErrorHandling('GET /api/runs', async (request: Request) => {
   const { searchParams } = new URL(request.url);
@@ -9,7 +10,8 @@ export const GET = withRouteErrorHandling('GET /api/runs', async (request: Reque
 
   if (apiUrl) {
     try {
-      const qs = searchParams.toString();
+      const sanitizedSearchParams = sanitizeSearchParams(searchParams);
+      const qs = sanitizedSearchParams.toString();
       const res = await fetch(`${apiUrl}/api/runs${qs ? `?${qs}` : ''}`, {
         cache: 'no-store',
       });

--- a/apps/web/src/lib/sanitize.ts
+++ b/apps/web/src/lib/sanitize.ts
@@ -12,3 +12,11 @@ export function sanitizeUrl(url: string): string {
 export function sanitizeMarkdown(md: string): string {
   return md.replace(MARKDOWN_DANGEROUS_LINK, "$1");
 }
+
+export function sanitizeSearchParams(searchParams: URLSearchParams): URLSearchParams {
+  const sanitized = new URLSearchParams();
+  for (const [key, value] of searchParams.entries()) {
+    sanitized.append(key, sanitizeUrl(value));
+  }
+  return sanitized;
+}


### PR DESCRIPTION
Implemented URL‑parameter sanitization to block dangerous schemes and updated the `/api/runs` handler to use this sanitization, preventing unsafe query values from reaching the backend.

Closes #932
Closes #935

