### PR TITLE
feat(a11y): add keyboard navigation for data tables

### DIFF
--- a/apps/web/src/app/RunHistoryTable.tsx
+++ b/apps/web/src/app/RunHistoryTable.tsx
@@ -2,6 +2,7 @@
 
 import { FuzzingRun, RunStatus } from './types';
 import AddReplayFromUiAction from './add-replay-from-ui-action';
+import { useDataTableKeyboardNav } from './use-data-table-keyboard-nav';
 
 interface RunHistoryTableProps {
     /** Array of fuzzing runs to display */
@@ -43,6 +44,16 @@ export default function RunHistoryTable({
     onReplayRun,
     visibleColumns = ['id', 'status', 'duration', 'seedCount', 'report'] 
 }: RunHistoryTableProps) {
+    const { getRowProps } = useDataTableKeyboardNav({
+        rowCount: runs.length,
+        onActivate: (index) => {
+            const run = runs[index];
+            if (run) {
+                onSelectRun(run.id);
+            }
+        },
+    });
+
     if (runs.length === 0) {
         return (
             <div className="flex flex-col items-center justify-center p-12 border border-dashed rounded-xl bg-zinc-50 dark:bg-zinc-900/20 border-zinc-200 dark:border-zinc-800">
@@ -55,7 +66,7 @@ export default function RunHistoryTable({
     return (
         <div className="w-full overflow-hidden border border-zinc-200 dark:border-zinc-800 rounded-xl shadow-sm bg-white dark:bg-zinc-950">
             <div className="overflow-x-auto">
-                <table className="w-full text-left border-collapse">
+                <table className="w-full text-left border-collapse" aria-label="Fuzzing run history">
                     <thead>
                         <tr className="bg-zinc-50 dark:bg-zinc-900/50 border-b border-zinc-200 dark:border-zinc-800">
                             {visibleColumns.includes('id') && <th className="px-6 py-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100">Run ID</th>}
@@ -67,18 +78,13 @@ export default function RunHistoryTable({
                         </tr>
                     </thead>
                     <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                        {runs.map((run) => (
+                        {runs.map((run, index) => (
                             <tr
                                 key={run.id}
-                                tabIndex={0}
+                                {...getRowProps(index)}
                                 className="group hover:bg-zinc-50 dark:hover:bg-zinc-900/30 transition-colors cursor-pointer"
                                 onClick={() => onSelectRun(run.id)}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter' || e.key === ' ') {
-                                        e.preventDefault();
-                                        onSelectRun(run.id);
-                                    }
-                                }}
+                                aria-label={`Fuzzing run ${run.id}, status ${run.status}`}
                             >
                                 {visibleColumns.includes('id') && (
                                     <td className="px-6 py-4">

--- a/apps/web/src/app/add-run-replay-history-with-timestamps.tsx
+++ b/apps/web/src/app/add-run-replay-history-with-timestamps.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   appendReplayHistoryEntry,
@@ -15,6 +16,7 @@ import {
   serializeReplayHistory,
   sortReplayHistoryByTimestamp,
 } from "./run-replay-history-utils";
+import { useDataTableKeyboardNav } from "./use-data-table-keyboard-nav";
 
 interface AddRunReplayHistoryWithTimestampsProps {
   /** When set, only replays sourced from this run are shown. */
@@ -61,6 +63,7 @@ export default function AddRunReplayHistoryWithTimestamps({
   sourceRunId,
   title = "Replay History",
 }: AddRunReplayHistoryWithTimestampsProps) {
+  const router = useRouter();
   const [history, setHistory] = useState<RunReplayHistoryEntry[]>([]);
   const [now, setNow] = useState(() => new Date());
 
@@ -91,6 +94,16 @@ export default function AddRunReplayHistoryWithTimestamps({
     return sortReplayHistoryByTimestamp(filtered, "desc");
   }, [history, sourceRunId]);
 
+  const { getRowProps } = useDataTableKeyboardNav({
+    rowCount: visibleHistory.length,
+    onActivate: (index) => {
+      const entry = visibleHistory[index];
+      if (entry) {
+        router.push(`/runs/${entry.replayRunId}`);
+      }
+    },
+  });
+
   return (
     <section
       className="card card-padding"
@@ -119,20 +132,26 @@ export default function AddRunReplayHistoryWithTimestamps({
         </div>
       ) : (
         <div className="table-responsive">
-          <table className="data-table">
+          <table className="data-table" aria-label="Run replay history">
             <thead>
               <tr>
-                <th>Replay Run</th>
-                {!sourceRunId && <th>Source Run</th>}
-                <th>Started</th>
-                <th>Completed</th>
-                <th>Duration</th>
-                <th>Status</th>
+                <th scope="col">Replay Run</th>
+                {!sourceRunId && <th scope="col">Source Run</th>}
+                <th scope="col">Started</th>
+                <th scope="col">Completed</th>
+                <th scope="col">Duration</th>
+                <th scope="col">Status</th>
               </tr>
             </thead>
             <tbody>
-              {visibleHistory.map((entry) => (
-                <tr key={entry.id}>
+              {visibleHistory.map((entry, index) => (
+                <tr
+                  key={entry.id}
+                  {...getRowProps(index)}
+                  className="cursor-pointer"
+                  onClick={() => router.push(`/runs/${entry.replayRunId}`)}
+                  aria-label={`Replay run ${entry.replayRunId}, status ${entry.status}`}
+                >
                   <td>
                     <Link href={`/runs/${entry.replayRunId}`} className="link code-text">
                       {entry.replayRunId}

--- a/apps/web/src/app/data-table-keyboard-nav-utils.test.ts
+++ b/apps/web/src/app/data-table-keyboard-nav-utils.test.ts
@@ -1,0 +1,78 @@
+import * as assert from "node:assert/strict";
+import {
+  DATA_TABLE_ACTIVATION_KEYS,
+  DATA_TABLE_NAVIGATION_KEYS,
+  getDataTableRowTabIndex,
+  resolveDataTableRowKeyDown,
+} from "./data-table-keyboard-nav-utils";
+
+function testActivationKeys(): void {
+  for (const key of ["Enter", " "]) {
+    assert.deepEqual(resolveDataTableRowKeyDown(key, 1, 5), { type: "activate" });
+  }
+  assert.ok(DATA_TABLE_ACTIVATION_KEYS.has("Enter"));
+  assert.ok(DATA_TABLE_ACTIVATION_KEYS.has(" "));
+}
+
+function testArrowNavigation(): void {
+  assert.deepEqual(resolveDataTableRowKeyDown("ArrowDown", 0, 5), {
+    type: "focus",
+    index: 1,
+  });
+  assert.deepEqual(resolveDataTableRowKeyDown("ArrowDown", 4, 5), {
+    type: "focus",
+    index: 4,
+  });
+  assert.deepEqual(resolveDataTableRowKeyDown("ArrowUp", 2, 5), {
+    type: "focus",
+    index: 1,
+  });
+  assert.deepEqual(resolveDataTableRowKeyDown("ArrowUp", 0, 5), {
+    type: "focus",
+    index: 0,
+  });
+  assert.ok(DATA_TABLE_NAVIGATION_KEYS.has("ArrowDown"));
+  assert.ok(DATA_TABLE_NAVIGATION_KEYS.has("ArrowUp"));
+}
+
+function testHomeEndNavigation(): void {
+  assert.deepEqual(resolveDataTableRowKeyDown("Home", 3, 5), {
+    type: "focus",
+    index: 0,
+  });
+  assert.deepEqual(resolveDataTableRowKeyDown("End", 1, 5), {
+    type: "focus",
+    index: 4,
+  });
+}
+
+function testEmptyTable(): void {
+  assert.deepEqual(resolveDataTableRowKeyDown("ArrowDown", 0, 0), {
+    type: "none",
+  });
+  assert.equal(getDataTableRowTabIndex(0, null, 0), -1);
+}
+
+function testRovingTabIndex(): void {
+  assert.equal(getDataTableRowTabIndex(0, null, 4), 0);
+  assert.equal(getDataTableRowTabIndex(1, null, 4), -1);
+  assert.equal(getDataTableRowTabIndex(2, 2, 4), 0);
+  assert.equal(getDataTableRowTabIndex(1, 2, 4), -1);
+}
+
+function testUnhandledKeys(): void {
+  assert.deepEqual(resolveDataTableRowKeyDown("Tab", 0, 3), { type: "none" });
+  assert.deepEqual(resolveDataTableRowKeyDown("Escape", 0, 3), { type: "none" });
+}
+
+function runAssertions(): void {
+  testActivationKeys();
+  testArrowNavigation();
+  testHomeEndNavigation();
+  testEmptyTable();
+  testRovingTabIndex();
+  testUnhandledKeys();
+  console.log("data-table-keyboard-nav-utils: all assertions passed");
+}
+
+runAssertions();

--- a/apps/web/src/app/data-table-keyboard-nav-utils.ts
+++ b/apps/web/src/app/data-table-keyboard-nav-utils.ts
@@ -1,0 +1,83 @@
+/**
+ * Keyboard navigation helpers for accessible data tables.
+ *
+ * Implements the roving-tabindex pattern: arrow keys move focus between rows,
+ * Home/End jump to the first/last row, and Enter/Space activate the row.
+ *
+ * Issue: #933 - [a11y] Add keyboard navigation for data tables
+ */
+
+export type DataTableNavAction =
+  | { type: "activate" }
+  | { type: "focus"; index: number }
+  | { type: "none" };
+
+/** Keys that move focus to another row instead of activating the current row. */
+export const DATA_TABLE_NAVIGATION_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+]);
+
+/** Keys that activate the focused row (open details, follow primary action). */
+export const DATA_TABLE_ACTIVATION_KEYS = new Set(["Enter", " "]);
+
+/**
+ * Resolve the keyboard action for a focused table row.
+ * Returns `none` for unhandled keys or empty tables.
+ */
+export function resolveDataTableRowKeyDown(
+  key: string,
+  currentIndex: number,
+  rowCount: number,
+): DataTableNavAction {
+  if (rowCount <= 0) {
+    return { type: "none" };
+  }
+
+  if (DATA_TABLE_ACTIVATION_KEYS.has(key)) {
+    return { type: "activate" };
+  }
+
+  if (key === "ArrowDown") {
+    return {
+      type: "focus",
+      index: Math.min(currentIndex + 1, rowCount - 1),
+    };
+  }
+
+  if (key === "ArrowUp") {
+    return {
+      type: "focus",
+      index: Math.max(currentIndex - 1, 0),
+    };
+  }
+
+  if (key === "Home") {
+    return { type: "focus", index: 0 };
+  }
+
+  if (key === "End") {
+    return { type: "focus", index: rowCount - 1 };
+  }
+
+  return { type: "none" };
+}
+
+/**
+ * Roving tabindex: only the focused row (or the first row when none is focused)
+ * participates in the tab order.
+ */
+export function getDataTableRowTabIndex(
+  rowIndex: number,
+  focusedIndex: number | null,
+  rowCount: number,
+): number {
+  if (rowCount <= 0) {
+    return -1;
+  }
+
+  const activeIndex = focusedIndex ?? 0;
+  return rowIndex === activeIndex ? 0 : -1;
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -417,6 +417,12 @@ body {
   background: var(--hover-bg);
 }
 
+.data-table tbody tr[tabindex="0"]:focus-visible td {
+  background: var(--hover-bg);
+  outline: 2px solid #0A66C2;
+  outline-offset: -2px;
+}
+
 .chip {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/app/implement-run-history-table-component.tsx
+++ b/apps/web/src/app/implement-run-history-table-component.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useMemo } from "react";
 import { FuzzingRun, RunStatus, RunSeverity } from "./types";
+import { useDataTableKeyboardNav } from "./use-data-table-keyboard-nav";
 import {
   getSortIndicator,
   getNextSortState,
@@ -133,6 +134,16 @@ export default function EnhancedRunHistoryTable({
     });
   }, [runs, sort]);
 
+  const { getRowProps } = useDataTableKeyboardNav({
+    rowCount: sortedRuns.length,
+    onActivate: (index) => {
+      const run = sortedRuns[index];
+      if (run) {
+        onSelectRun(run.id);
+      }
+    },
+  });
+
   const toggleSort = (field: keyof FuzzingRun & string) => {
     setSort((current) => getNextSortState(current, field));
   };
@@ -186,7 +197,7 @@ export default function EnhancedRunHistoryTable({
   return (
     <div className="w-full bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-3xl overflow-hidden shadow-2xl transition-all hover:shadow-blue-500/5">
       <div className="overflow-x-auto">
-        <table className="w-full text-left border-collapse">
+        <table className="w-full text-left border-collapse" aria-label="Fuzzing run history">
           <thead>
             <tr className="bg-zinc-50/50 dark:bg-zinc-900/50 border-b border-zinc-100 dark:border-zinc-900">
               {onToggleRunSelection && (
@@ -260,9 +271,10 @@ export default function EnhancedRunHistoryTable({
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-50 dark:divide-zinc-900/50">
-            {sortedRuns.map((run) => (
+            {sortedRuns.map((run, index) => (
               <tr
                 key={run.id}
+                {...getRowProps(index)}
                 className={`group transition-all cursor-pointer ${
                   selectedRunIds.has(run.id) 
                     ? "bg-blue-50/80 dark:bg-blue-900/20" 
@@ -273,6 +285,7 @@ export default function EnhancedRunHistoryTable({
                      onSelectRun(run.id);
                   }
                 }}
+                aria-label={`Fuzzing run ${run.id}, status ${run.status}`}
               >
                 {onToggleRunSelection && (
                   <td className="px-6 py-5" onClick={(e) => e.stopPropagation()}>

--- a/apps/web/src/app/implement-virtualized-run-table-component.tsx
+++ b/apps/web/src/app/implement-virtualized-run-table-component.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FuzzingRun, RunStatus } from './types';
 import { formatDuration } from './utils/format';
+import { useDataTableKeyboardNav } from './use-data-table-keyboard-nav';
+import type { DataTableRowKeyboardProps } from './use-data-table-keyboard-nav';
 
 /** Height of a single data row in pixels — must match the rendered row height. */
 const ROW_HEIGHT = 57;
@@ -51,6 +53,7 @@ const VirtualRow = ({
     visibleColumns,
     selectedRunIds = new Set(),
     onToggleRunSelection,
+    rowKeyboardProps,
 }: {
     run: FuzzingRun;
     top: number;
@@ -59,28 +62,18 @@ const VirtualRow = ({
     visibleColumns: string[];
     selectedRunIds?: Set<string>;
     onToggleRunSelection?: (id: string) => void;
+    rowKeyboardProps: DataTableRowKeyboardProps;
 }) => {
-    const handleKeyDown = useCallback(
-        (e: React.KeyboardEvent<HTMLTableRowElement>) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onSelectRun(run.id);
-            }
-        },
-        [run.id, onSelectRun],
-    );
-
     return (
         <tr
             style={{ position: 'absolute', top, left: 0, right: 0, height: ROW_HEIGHT, display: 'flex', alignItems: 'center' }}
-            tabIndex={0}
+            {...rowKeyboardProps}
             className={`group transition-colors cursor-pointer border-b border-zinc-100 dark:border-zinc-800 w-full ${
                 selectedRunIds.has(run.id)
                     ? "bg-blue-50/80 dark:bg-blue-900/20"
                     : "hover:bg-zinc-50 dark:hover:bg-zinc-900/30"
             }`}
             onClick={() => onSelectRun(run.id)}
-            onKeyDown={handleKeyDown}
             aria-label={`Fuzzing run ${run.id}, status ${run.status}`}
         >
             {onToggleRunSelection && (
@@ -183,6 +176,24 @@ export default function VirtualizedRunTable({
 }: VirtualizedRunTableProps) {
     const scrollRef = useRef<HTMLDivElement>(null);
     const [scrollTop, setScrollTop] = useState(0);
+
+    const { getRowProps } = useDataTableKeyboardNav({
+        rowCount: runs.length,
+        onActivate: (index) => {
+            const run = runs[index];
+            if (run) {
+                onSelectRun(run.id);
+            }
+        },
+        onFocusRow: (index) => {
+            const el = scrollRef.current;
+            if (!el) {
+                return;
+            }
+            el.scrollTop = index * ROW_HEIGHT;
+            setScrollTop(index * ROW_HEIGHT);
+        },
+    });
 
     /** Recalculate on scroll — wrapped in useCallback for stable identity. */
     const handleScroll = useCallback(() => {
@@ -314,18 +325,22 @@ export default function VirtualizedRunTable({
                         <tbody
                             style={{ position: 'relative', display: 'block', height: totalHeight }}
                         >
-                            {visibleRuns.map((run, i) => (
+                            {visibleRuns.map((run, i) => {
+                                const rowIndex = firstVisible + i;
+                                return (
                                 <VirtualRow
                                     key={run.id}
                                     run={run}
-                                    top={(firstVisible + i) * ROW_HEIGHT}
+                                    top={rowIndex * ROW_HEIGHT}
                                     onSelectRun={onSelectRun}
                                     onViewReport={onViewReport}
                                     visibleColumns={visibleColumns}
                                     selectedRunIds={selectedRunIds}
                                     onToggleRunSelection={onToggleRunSelection}
+                                    rowKeyboardProps={getRowProps(rowIndex)}
                                 />
-                            ))}
+                            );
+                            })}
                         </tbody>
                     </table>
                 </div>

--- a/apps/web/src/app/keyboard-shortcut-cheatsheet-utils.ts
+++ b/apps/web/src/app/keyboard-shortcut-cheatsheet-utils.ts
@@ -67,7 +67,7 @@ export const KEYBOARD_SHORTCUT_CHEATSHEET: KeyboardShortcut[] = [
     id: "navigate-rows",
     category: "dashboard",
     keys: ["↑", "↓"],
-    description: "Move selection between fuzzing runs in tables",
+    description: "Move between rows in data tables (Home/End jump to first/last row)",
   },
   {
     id: "open-run",

--- a/apps/web/src/app/logs/page.tsx
+++ b/apps/web/src/app/logs/page.tsx
@@ -22,6 +22,7 @@ import {
 } from './log-viewer-page-utils';
 import { useDebounce } from '../../lib/useDebounce';
 import { MOCK_LOG_ENTRIES } from '../../fixtures/logs';
+import { useDataTableKeyboardNav } from '../use-data-table-keyboard-nav';
 
 async function fetchLogs(): Promise<LogEntry[]> {
   await new Promise((r) => setTimeout(r, 800));
@@ -126,6 +127,19 @@ export default function LogViewerPage() {
     [entries, levelFilter, debouncedSearchQuery],
   );
 
+  const { getRowProps } = useDataTableKeyboardNav({
+    rowCount: visible.length,
+    onActivate: (index) => {
+      const entry = visible[index];
+      if (!entry) {
+        return;
+      }
+      const row = document.getElementById(logEntryAnchorId(entry));
+      row?.scrollIntoView({ block: 'nearest' });
+      row?.querySelector<HTMLElement>('a')?.focus();
+    },
+  });
+
   return (
     <div className="container-full page-padding fade-in">
       {/* Page header */}
@@ -201,7 +215,10 @@ export default function LogViewerPage() {
 
             {/* Log table */}
             <div className="table-responsive">
-              <table className="data-table w-full text-xs sm:text-sm font-mono">
+              <table
+                className="data-table w-full text-xs sm:text-sm font-mono"
+                aria-label="Log entries"
+              >
                 <thead>
                   <tr>
                     <th scope="col" className="w-24 sm:w-52">Timestamp</th>
@@ -211,8 +228,13 @@ export default function LogViewerPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {visible.map((entry) => (
-                    <tr key={entry.id} id={logEntryAnchorId(entry)}>
+                  {visible.map((entry, index) => (
+                    <tr
+                      key={entry.id}
+                      id={logEntryAnchorId(entry)}
+                      {...getRowProps(index)}
+                      aria-label={`Log entry ${entry.level} from ${entry.source}`}
+                    >
                       <td className="text-meta whitespace-nowrap text-[10px] sm:text-xs">
                         <a
                           href={logEntryAnchorHref(entry)}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,6 +13,7 @@ const AddTaggingAndLabelsUi = dynamic(
 import { runMatchesTagFilter } from "./run-tags-utils";
 import { FuzzingRun } from "./types";
 import { fetchRuns } from "../lib/api-client";
+import { useDataTableKeyboardNav } from "./use-data-table-keyboard-nav";
 
 const makeSuggestedLabels = (run: FuzzingRun): string[] => [
   run.area,
@@ -72,6 +73,16 @@ function DashboardContent() {
 
   const recentRuns = filteredRuns.slice(0, 8);
 
+  const { getRowProps } = useDataTableKeyboardNav({
+    rowCount: recentRuns.length,
+    onActivate: (index) => {
+      const run = recentRuns[index];
+      if (run) {
+        router.push(`/runs/${run.id}`);
+      }
+    },
+  });
+
   return (
     <div className="container-full page-padding fade-in">
       <div className="flex items-center justify-between mb-4 sm:mb-6">
@@ -112,13 +123,16 @@ function DashboardContent() {
               <Link href="/runs" className="link text-xs sm:text-sm">View all</Link>
             </div>
             <div className="card table-responsive">
-                <table className="data-table">
+                <table
+                  className="data-table"
+                  aria-label="Recent fuzzing runs"
+                >
                   <thead>
                     <tr>
-                      <th>ID</th>
-                      <th>Status</th>
-                      <th>Area</th>
-                      <th>Tags</th>
+                      <th scope="col">ID</th>
+                      <th scope="col">Status</th>
+                      <th scope="col">Area</th>
+                      <th scope="col">Tags</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -136,8 +150,14 @@ function DashboardContent() {
                         </td>
                       </tr>
                     ) : (
-                      recentRuns.map((run) => (
-                        <tr key={run.id}>
+                      recentRuns.map((run, index) => (
+                        <tr
+                          key={run.id}
+                          {...getRowProps(index)}
+                          className="cursor-pointer"
+                          onClick={() => router.push(`/runs/${run.id}`)}
+                          aria-label={`Fuzzing run ${run.id}, status ${run.status}`}
+                        >
                           <td className="code-text text-meta">{run.id}</td>
                           <td><span className={`badge badge-${run.status}`}>{run.status}</span></td>
                           <td>{run.area}</td>

--- a/apps/web/src/app/use-data-table-keyboard-nav.ts
+++ b/apps/web/src/app/use-data-table-keyboard-nav.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import {
+  useCallback,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefCallback,
+} from "react";
+import {
+  getDataTableRowTabIndex,
+  resolveDataTableRowKeyDown,
+} from "./data-table-keyboard-nav-utils";
+
+export interface DataTableRowKeyboardProps {
+  tabIndex: number;
+  onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+  onFocus: () => void;
+  ref: RefCallback<HTMLElement>;
+}
+
+interface UseDataTableKeyboardNavOptions {
+  rowCount: number;
+  onActivate?: (index: number) => void;
+  onFocusRow?: (index: number) => void;
+  enabled?: boolean;
+}
+
+/**
+ * Hook that wires roving-tabindex keyboard navigation into table rows.
+ * Spread the returned props onto each focusable `<tr>` (or row container).
+ */
+export function useDataTableKeyboardNav({
+  rowCount,
+  onActivate,
+  onFocusRow,
+  enabled = true,
+}: UseDataTableKeyboardNavOptions) {
+  const rowRefs = useRef<Map<number, HTMLElement>>(new Map());
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+
+  const focusRow = useCallback(
+    (index: number) => {
+      if (!enabled || index < 0 || index >= rowCount) {
+        return;
+      }
+
+      onFocusRow?.(index);
+      const attemptFocus = () => {
+        const row = rowRefs.current.get(index);
+        if (row) {
+          row.focus();
+          setFocusedIndex(index);
+        }
+      };
+      attemptFocus();
+      requestAnimationFrame(attemptFocus);
+    },
+    [enabled, onFocusRow, rowCount],
+  );
+
+  const getRowProps = useCallback(
+    (index: number): DataTableRowKeyboardProps => {
+      const setRef: RefCallback<HTMLElement> = (element) => {
+        if (element) {
+          rowRefs.current.set(index, element);
+        } else {
+          rowRefs.current.delete(index);
+        }
+      };
+
+      return {
+        tabIndex: enabled
+          ? getDataTableRowTabIndex(index, focusedIndex, rowCount)
+          : -1,
+        onFocus: () => setFocusedIndex(index),
+        ref: setRef,
+        onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+          if (!enabled) {
+            return;
+          }
+
+          const action = resolveDataTableRowKeyDown(
+            event.key,
+            index,
+            rowCount,
+          );
+
+          if (action.type === "activate") {
+            event.preventDefault();
+            onActivate?.(index);
+            return;
+          }
+
+          if (action.type === "focus") {
+            event.preventDefault();
+            focusRow(action.index);
+          }
+        },
+      };
+    },
+    [enabled, focusRow, focusedIndex, onActivate, rowCount],
+  );
+
+  return { getRowProps, focusedIndex, focusRow };
+}


### PR DESCRIPTION
## Overview
This PR adds accessible keyboard navigation to data tables across the web dashboard so users can browse and activate table rows without a mouse. It introduces a shared roving-tabindex navigation layer supporting arrow keys, Home/End, and Enter/Space activation, and wires it into all primary run and log tables.

## Related Issue
Closes #933

## Changes

### ⌨️ Keyboard Navigation Utilities
- **[ADD]** `apps/web/src/app/data-table-keyboard-nav-utils.ts`
- Added pure helpers for data-table row keyboard actions.
- Implemented `↑` / `↓` row navigation with boundary handling.
- Implemented `Home` / `End` to jump to the first and last row.
- Implemented `Enter` / `Space` row activation.
- Added roving-tabindex helpers so only one row is in the tab order at a time.

- **[ADD]** `apps/web/src/app/use-data-table-keyboard-nav.ts`
- Added a React hook that applies keyboard navigation props to table rows.
- Supports row activation callbacks and optional scroll-into-view for virtualized tables.

### 📋 Table Integrations
- **[MODIFY]** `apps/web/src/app/page.tsx`
- Added keyboard navigation to the dashboard recent runs table.
- Rows now open run details on Enter/Space and click.

- **[MODIFY]** `apps/web/src/app/logs/page.tsx`
- Added keyboard navigation to the log viewer data table.
- Enter/Space focuses the row timestamp anchor.

- **[MODIFY]** `apps/web/src/app/RunHistoryTable.tsx`
- Replaced basic Enter/Space handling with full arrow-key navigation.

- **[MODIFY]** `apps/web/src/app/implement-run-history-table-component.tsx`
- Added keyboard navigation to the enhanced run history table.

- **[MODIFY]** `apps/web/src/app/implement-virtualized-run-table-component.tsx`
- Added keyboard navigation with scroll-into-view for virtualized rows.

- **[MODIFY]** `apps/web/src/app/add-run-replay-history-with-timestamps.tsx`
- Added keyboard navigation to the replay history table.

### 🎨 Accessibility & Docs
- **[MODIFY]** `apps/web/src/app/globals.css`
- Added visible focus styles for focused data-table rows.

- **[MODIFY]** `apps/web/src/app/keyboard-shortcut-cheatsheet-utils.ts`
- Updated cheatsheet copy to document table row navigation including Home/End.

### 🧪 Tests
- **[ADD]** `apps/web/src/app/data-table-keyboard-nav-utils.test.ts`
- Added tests for arrow-key navigation and boundary behavior.
- Added tests for Home/End navigation.
- Added tests for activation keys and roving tabindex.

## Verification Results

| Check | Status |
|---|---|
| `npm run lint` | ✅ completed (existing repo warnings only) |
| `npx tsc --noEmit` (changed files) | ✅ passed |
| `data-table-keyboard-nav-utils.test.ts` | ✅ passed |
| Keyboard navigation wired into all primary data tables | ✅ |
| Commit author verified as Zeemnew | ✅ |