### PR TITLE
fix(web): read settings config from localStorage at init to eliminate stale first paint

### DIFF
--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,23 +1,30 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useMaintainerMode } from '../useMaintainerMode';
 import { loadFromStorage } from './api/api-config-utils';
 
+function readActiveUrl(): string {
+  const config = loadFromStorage();
+  return config.backendUrl || process.env.NEXT_PUBLIC_API_URL || '';
+}
+
+function getInitialApiUrl(): string {
+  if (typeof window === 'undefined') return '';
+  const activeUrl = readActiveUrl();
+  return activeUrl || 'Not configured (using mock data)';
+}
+
+function getInitialIsMockData(): boolean {
+  if (typeof window === 'undefined') return true;
+  return !readActiveUrl();
+}
+
 export default function SettingsPage() {
   const { isMaintainer, toggle: toggleMaintainer, mounted, storageError } = useMaintainerMode();
-  const [apiUrl, setApiUrl] = useState<string>('');
-  const [isMockData, setIsMockData] = useState<boolean>(true);
-
-  useEffect(() => {
-    queueMicrotask(() => {
-      const config = loadFromStorage();
-      const activeUrl = config.backendUrl || process.env.NEXT_PUBLIC_API_URL || '';
-      setApiUrl(activeUrl || 'Not configured (using mock data)');
-      setIsMockData(!activeUrl);
-    });
-  }, []);
+  const [apiUrl] = useState<string>(getInitialApiUrl);
+  const [isMockData] = useState<boolean>(getInitialIsMockData);
   return (
     <div className="container-full page-padding fade-in">
       <div className="mb-4 sm:mb-6">


### PR DESCRIPTION
## Closes #1064

### Problem

The Settings page used `queueMicrotask` inside a `useEffect` to defer reading API configuration from `localStorage`. This caused the component to always render with stale default values (empty `apiUrl`, `isMockData = true`) on first paint, briefly showing `'Not configured (using mock data)'` even when the user had a configured backend URL. After the microtask fired, the state updated and re-rendered with correct values, producing a visible flash.

### Root Cause

In `apps/web/src/app/settings/page.tsx`:
`	sx
// State always starts as empty/defaultconst [apiUrl, setApiUrl] = useState<string>('');const [isMockData, setIsMockData] = useState<boolean>(true);

// Deferred read - too late for first paintuseEffect(() => {  queueMicrotask(() => {    const config = loadFromStorage();    ...  });}, []);
`

### Fix

Replace the `useState` + `useEffect`/`queueMicrotask` pattern with lazy `useState` initializers that read from `localStorage` during component initialization, guarded by `typeof window === 'undefined'` for SSR safety:
`	sx
function getInitialApiUrl(): string {  if (typeof window === 'undefined') return '';  const config = loadFromStorage();  const activeUrl = config.backendUrl || process.env.NEXT_PUBLIC_API_URL || '';  return activeUrl || 'Not configured (using mock data)';}

const [apiUrl] = useState<string>(getInitialApiUrl);const [isMockData] = useState<boolean>(getInitialIsMockData);
`

This ensures the first paint already reflects the correct configuration from `localStorage`. The pattern matches what `ApiConfigForm.tsx` already uses.

### Changes

- `apps/web/src/app/settings/page.tsx` - Initialize state from `localStorage` at construction time instead of deferring via `queueMicrotask`; removed unused `useEffect` import

### Verification

-  `npm run lint` - 0 errors
-  `npm test` - all tests pass
-  `npm run build` - Turbopack internal error (pre-existing Windows environment issue, unrelated to this change)