### PR TITLE
fix(web): persist mock data stores via globalThis to survive HMR and warm serverless starts

### DIFF
--- a/apps/web/src/app/api/mock-store.ts
+++ b/apps/web/src/app/api/mock-store.ts
@@ -1,0 +1,34 @@
+/**
+ * Persistent mock data stores backed by globalThis.
+ *
+ * Plain module-level `new Map()` instances are destroyed on every hot-module
+ * reload during development and on serverless cold starts (Vercel).  Storing
+ * the maps on `globalThis` keeps them alive across HMR cycles and warm
+ * serverless invocations within the same process.
+ *
+ * On a genuine cold start the maps are re-created empty and seeded lazily by
+ * the existing `getTags` / `getAnnotations` / `getIssues` helpers in each
+ * route file, so the user always sees a consistent initial dataset.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const g = globalThis as Record<string, any>;
+
+function getOrCreateMap<V>(key: string): Map<string, V> {
+  if (!(g[key] instanceof Map)) {
+    g[key] = new Map<string, V>();
+  }
+  return g[key] as Map<string, V>;
+}
+
+export function getTagStore(): Map<string, string[]> {
+  return getOrCreateMap<string[]>('__crashlab_tagStore');
+}
+
+export function getAnnotationStore(): Map<string, string[]> {
+  return getOrCreateMap<string[]>('__crashlab_annotationStore');
+}
+
+export function getIssueStore<V>(): Map<string, V[]> {
+  return getOrCreateMap<V[]>('__crashlab_issueStore');
+}

--- a/apps/web/src/app/api/runs/[id]/annotations/route.ts
+++ b/apps/web/src/app/api/runs/[id]/annotations/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { buildMockRuns } from '@/app/mockRuns';
+import { getAnnotationStore } from '@/app/api/mock-store';
 import { jsonError, readJsonBody, withRouteErrorHandling } from '@/lib/route-handler';
 
-const annotationStore = new Map<string, string[]>();
+const annotationStore = getAnnotationStore();
 
 function getAnnotations(id: string): string[] {
   if (annotationStore.has(id)) {

--- a/apps/web/src/app/api/runs/[id]/issues/route.ts
+++ b/apps/web/src/app/api/runs/[id]/issues/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { buildMockRuns } from '@/app/mockRuns';
 import type { RunIssueLink } from '@/app/types';
+import { getIssueStore } from '@/app/api/mock-store';
 import { tryBackend } from '@/lib/api-proxy';
 import { jsonError, readJsonBody, withRouteErrorHandling } from '@/lib/route-handler';
 
 const ISSUES_API_URL = process.env.ISSUES_API_URL || process.env.NEXT_PUBLIC_API_URL;
 
-const issueStore = new Map<string, RunIssueLink[]>();
+const issueStore = getIssueStore<RunIssueLink>();
 
 function getIssues(id: string): RunIssueLink[] {
   if (issueStore.has(id)) {

--- a/apps/web/src/app/api/runs/[id]/tags/route.ts
+++ b/apps/web/src/app/api/runs/[id]/tags/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { buildMockRuns } from '@/app/mockRuns';
 import { addTag, normalizeTag, removeTag } from '@/app/run-tags-utils';
+import { getTagStore } from '@/app/api/mock-store';
 import { jsonError, readJsonBody, withRouteErrorHandling } from '@/lib/route-handler';
 
-const tagStore = new Map<string, string[]>();
+const tagStore = getTagStore();
 
 function getTags(id: string): string[] {
   if (!tagStore.has(id)) {


### PR DESCRIPTION
## Closes #1066

### Problem

The in-memory `Map` stores (`tagStore`, `annotationStore`, `issueStore`) in the mock API routes were plain module-level instances destroyed on every HMR cycle and serverless cold start. User mutations (added tags, annotations, issue links) were silently lost.

Affected stores:
- `tagStore` in `api/runs/[id]/tags/route.ts`
- `annotationStore` in `api/runs/[id]/annotations/route.ts`
- `issueStore` in `api/runs/[id]/issues/route.ts`

### Fix

Introduced `apps/web/src/app/api/mock-store.ts` utility that backs each `Map` on `globalThis`. This keeps the stores alive across:

- **HMR cycles** during development (no more data loss on file save)
- **Warm serverless invocations** on Vercel (same function instance handles multiple requests)

On a genuine cold start the stores are re-created empty and seeded lazily from `buildMockRuns()`, preserving the existing initial-state behavior.

### Files Changed
- `apps/web/src/app/api/mock-store.ts` (new) — globalThis-backed store factory with `getTagStore()`, `getAnnotationStore()`, `getIssueStore()`
- `apps/web/src/app/api/runs/[id]/tags/route.ts` — use `getTagStore()`
- `apps/web/src/app/api/runs/[id]/annotations/route.ts` — use `getAnnotationStore()`
- `apps/web/src/app/api/runs/[id]/issues/route.ts` — use `getIssueStore()`

### Verification
- `npm run lint` — 0 errors
- `npm test` — all tests pass