### PR TITLE
fix: resolves issue #1068 - Add CSRF state validation for GitHub OAuth callback

### DIFF
--- a/apps/web/src/app/api/auth/github/callback/route.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.ts
@@ -1,38 +1,63 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 
+const STATE_COOKIE_NAME = 'github_oauth_state';
+
 /**
  * GET /api/auth/github/callback
  * GitHub OAuth 2.0 callback route.
  *
- * This route handles the redirection from GitHub after a user has authorized the application.
- * It expects 'code' and 'state' as query parameters.
+ * Handles the redirect from GitHub after user authorization.
+ * Validates the CSRF state parameter before processing the code exchange.
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get('code');
   const state = searchParams.get('state');
+  const storedState = request.cookies.get(STATE_COOKIE_NAME)?.value;
 
-  // 1. Validate the presence of required parameters
+  // Clear the state cookie regardless of outcome
+  const clearCookie = (response: NextResponse) => {
+    response.cookies.delete(STATE_COOKIE_NAME);
+    return response;
+  };
+
   if (!code) {
-    return NextResponse.json(
-      { error: 'Missing "code" parameter from GitHub callback.' },
-      { status: 400 }
+    return clearCookie(
+      NextResponse.json(
+        { error: 'Missing "code" parameter from GitHub callback.' },
+        { status: 400 }
+      )
     );
   }
 
-  if (!state) {
-    logger.warn('GET /api/auth/github/callback: missing state parameter');
+  // Validate the CSRF state parameter
+  if (!state || !storedState) {
+    logger.warn('GET /api/auth/github/callback: missing state parameter (possible CSRF)');
+    return clearCookie(
+      NextResponse.json(
+        { error: 'Missing OAuth state parameter. The login flow may have expired or been tampered with.' },
+        { status: 403 }
+      )
+    );
+  }
+
+  if (state !== storedState) {
+    logger.warn('GET /api/auth/github/callback: state mismatch (possible CSRF attack)');
+    return clearCookie(
+      NextResponse.json(
+        { error: 'OAuth state mismatch. The request may have been tampered with.' },
+        { status: 403 }
+      )
+    );
   }
 
   try {
-    // 2. Simulate exchange of 'code' for an access token
     logger.info('GET /api/auth/github/callback: exchanging code for access token', { code });
 
     // Simulate API latency
     await new Promise((resolve) => setTimeout(resolve, 500));
 
-    // 3. Simulate fetching user profile with the access token
     const mockUser = {
       id: 123456,
       login: 'octocat',
@@ -42,15 +67,18 @@ export async function GET(request: NextRequest) {
 
     logger.info('GET /api/auth/github/callback: authenticated user', { login: mockUser.login });
 
-    // 4. Redirect user back to the dashboard with a success indicator
-    return NextResponse.redirect(new URL('/', request.url), {
+    const response = NextResponse.redirect(new URL('/', request.url), {
       status: 302,
     });
+
+    return clearCookie(response);
   } catch (error) {
     logger.error('GET /api/auth/github/callback failed', { error });
-    return NextResponse.json(
-      { error: 'An internal error occurred while processing the GitHub authentication.' },
-      { status: 500 }
+    return clearCookie(
+      NextResponse.json(
+        { error: 'An internal error occurred while processing the GitHub authentication.' },
+        { status: 500 }
+      )
     );
   }
 }

--- a/apps/web/src/app/api/auth/github/login/route.ts
+++ b/apps/web/src/app/api/auth/github/login/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+
+const GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
+const STATE_COOKIE_NAME = 'github_oauth_state';
+const STATE_MAX_AGE_SECONDS = 600;
+
+/**
+ * GET /api/auth/github/login
+ * Initiates the GitHub OAuth 2.0 flow.
+ *
+ * Generates a cryptographically random state parameter, stores it in a
+ * short-lived httpOnly cookie, and redirects the user to GitHub's
+ * authorization endpoint.
+ */
+export async function GET(request: NextRequest) {
+  const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID;
+
+  if (!clientId) {
+    logger.warn('GET /api/auth/github/login: GITHUB_CLIENT_ID is not configured');
+    return NextResponse.json(
+      { error: 'GitHub OAuth is not configured.' },
+      { status: 503 }
+    );
+  }
+
+  const state = crypto.randomUUID();
+
+  const { origin } = new URL(request.url);
+  const callbackUrl = `${origin}/api/auth/github/callback`;
+
+  const githubAuthParams = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: callbackUrl,
+    state,
+    scope: 'read:user user:email',
+  });
+
+  const response = NextResponse.redirect(
+    `${GITHUB_AUTH_URL}?${githubAuthParams.toString()}`,
+    { status: 302 }
+  );
+
+  response.cookies.set(STATE_COOKIE_NAME, state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: STATE_MAX_AGE_SECONDS,
+    path: '/',
+  });
+
+  logger.info('GET /api/auth/github/login: redirecting to GitHub with state');
+
+  return response;
+}


### PR DESCRIPTION
Closes #1068

## Summary

This PR fixes a CSRF vulnerability in the GitHub OAuth flow where the callback route accepted the `state` parameter but never validated it, allowing potential CSRF attacks.

## Changes

### New: `/api/auth/github/login` route (`apps/web/src/app/api/auth/github/login/route.ts`)
- Generates a cryptographically random `state` parameter via `crypto.randomUUID()`
- Stores it in an `httpOnly`, `secure`, `SameSite=Lax` cookie with a 10-minute TTL
- Redirects the user to GitHub's authorization endpoint with the `state` and `redirect_uri`

### Updated: `/api/auth/github/callback` route (`apps/web/src/app/api/auth/github/callback/route.ts`)
- **Validates** the `state` query parameter against the stored cookie value
- Returns `403 Forbidden` if state is missing or mismatched (possible CSRF)
- Clears the state cookie after every callback (success or failure)

## How it works

1. User visits `/api/auth/github/login`
2. Server generates a random `state`, saves it in an httpOnly cookie, redirects to GitHub
3. GitHub redirects back to `/api/auth/github/callback` with code and state
4. Server compares state from query with the cookie value
5. If they match, proceeds with code exchange; if not, returns 403
6. Cookie is cleared in all cases

## Verification

- `npm run lint` — 0 errors
- `npm test` — all tests pass