### PR TITLE
fix: close mobile nav drawer on route navigation

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -831,8 +831,6 @@ nav, header, .nav-bar {
   .parallax-fast,
   .lazy-enter,
   .lazy-enter-active,
-  .drawer,
-  .drawer.open,
   nav,
   header,
   .nav-bar,
@@ -841,6 +839,11 @@ nav, header, .nav-bar {
     transform: none !important;
     opacity: 1 !important;
     box-shadow: none !important;
+  }
+
+  .drawer.open {
+    transform: translateX(0) !important;
+    opacity: 1 !important;
   }
 }
 

--- a/apps/web/src/components/NavBar.tsx
+++ b/apps/web/src/components/NavBar.tsx
@@ -37,7 +37,7 @@ export default function NavBar() {
   }, []);
 
   useEffect(() => {
-    queueMicrotask(() => setDrawerOpen(false));
+    setDrawerOpen(false);
   }, [pathname]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes the mobile nav drawer not closing when navigating to a new route.

## Changes

### 1. NavBar.tsx — Fix timing race condition (line 40)
Replaced `queueMicrotask(() => setDrawerOpen(false))` with a direct `setDrawerOpen(false)` call inside the `useEffect` that watches `pathname`. The `queueMicrotask` wrapper introduced a timing gap where React's concurrent rendering or state batching could delay the close, leaving the drawer visually open for an extra render cycle.

### 2. globals.css — Fix prefers-reduced-motion CSS override (lines 828-847)
The `@media (prefers-reduced-motion: reduce)` rule applied `transform: none !important` and `opacity: 1 !important` to both `.drawer` and `.drawer.open`. This defeated the CSS-based hiding mechanism entirely — the drawer was always visually present for users with reduced motion preferences.

**Fix:** Removed `.drawer` and `.drawer.open` from the blanket override. The generic `* { transition-duration: 0.001ms !important } ` rule already disables animations. Added a specific `.drawer.open` rule that restores the correct visible state with `transform: translateX(0)` and `opacity: 1`, while the non-open `.drawer` retains its default `transform: translateX(100%)` to stay hidden.

## Testing
- Verified `queueMicrotask` is no longer present in NavBar.tsx
- Verified the reduced-motion block no longer forces drawer visibility when closed
- Verified `.drawer.open` still renders correctly in reduced-motion mode
- Verified no unrelated code was modified (only 2 files, +6/-3 lines)

Closes #1072