### PR TITLE
[#1083] Settings: reporting templates autosave fails silently on localStorage quota exceeded

### DIFF
--- a/apps/web/src/app/create-reporting-templates-page-60.test.ts
+++ b/apps/web/src/app/create-reporting-templates-page-60.test.ts
@@ -1,0 +1,72 @@
+import * as assert from 'node:assert/strict';
+import { isQuotaExceededError, safeWriteStorage } from './create-reporting-templates-page-60';
+
+// isQuotaExceededError — non-DOMException values
+assert.equal(isQuotaExceededError(null), false);
+assert.equal(isQuotaExceededError(undefined), false);
+assert.equal(isQuotaExceededError(new Error('generic')), false);
+
+// isQuotaExceededError — DOMException by name
+assert.equal(isQuotaExceededError(new DOMException('full', 'QuotaExceededError')), true);
+assert.equal(isQuotaExceededError(new DOMException('full', 'NS_ERROR_DOM_QUOTA_REACHED')), true);
+
+// isQuotaExceededError — unrelated DOMException
+assert.equal(isQuotaExceededError(new DOMException('not found', 'NotFoundError')), false);
+
+// isQuotaExceededError — legacy numeric codes
+// (DOMException#code is a getter-only property on the prototype in Node,
+// so Object.assign silently fails; defineProperty overrides it on the instance)
+function domExceptionWithLegacyCode(code: number): DOMException {
+  const error = new DOMException('full');
+  Object.defineProperty(error, 'code', { value: code, configurable: true });
+  return error;
+}
+
+assert.equal(isQuotaExceededError(domExceptionWithLegacyCode(22)), true);
+assert.equal(isQuotaExceededError(domExceptionWithLegacyCode(1014)), true);
+
+// safeWriteStorage — successful write returns true
+{
+  const store = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+    key: () => null,
+    length: 0,
+  } as Storage;
+
+  const ok = safeWriteStorage('some-key', 'some-value');
+  assert.equal(ok, true);
+  assert.equal(store.get('some-key'), 'some-value');
+}
+
+// safeWriteStorage — quota exceeded is caught and reported as failure, not thrown
+{
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: () => null,
+    setItem: () => {
+      throw new DOMException('quota exceeded', 'QuotaExceededError');
+    },
+    removeItem: () => undefined,
+    clear: () => undefined,
+    key: () => null,
+    length: 0,
+  } as Storage;
+
+  let threw = false;
+  let ok: boolean | undefined;
+  try {
+    ok = safeWriteStorage('some-key', 'some-value');
+  } catch {
+    threw = true;
+  }
+
+  assert.equal(threw, false, 'safeWriteStorage must not throw on quota exceeded');
+  assert.equal(ok, false, 'safeWriteStorage must report failure so callers can surface it to the user');
+}
+
+console.log('create-reporting-templates-page-60.test.ts: all assertions passed');

--- a/apps/web/src/app/create-reporting-templates-page-60.tsx
+++ b/apps/web/src/app/create-reporting-templates-page-60.tsx
@@ -76,11 +76,27 @@ function readSelectedTemplateIdFromStorage(): string | null {
   }
 }
 
-function safeWriteStorage(key: string, value: string) {
+export function isQuotaExceededError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === 'QuotaExceededError' ||
+      error.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+      error.code === 22 ||
+      error.code === 1014)
+  );
+}
+
+export function safeWriteStorage(key: string, value: string): boolean {
   try {
     localStorage.setItem(key, value);
-  } catch {
-    // ignore write errors (private mode, quota, etc.)
+    return true;
+  } catch (error) {
+    if (isQuotaExceededError(error)) {
+      console.warn(`localStorage quota exceeded, "${key}" will not persist`);
+    }
+    // Private mode, quota exceeded, or storage disabled: caller decides
+    // how to surface this to the user rather than failing silently.
+    return false;
   }
 }
 
@@ -114,21 +130,31 @@ export default function CreateReportingTemplatesPage60() {
     [selectedId, templates],
   );
 
-  useEffect(() => {
-    if (!hydrated) return;
-    safeWriteStorage(TEMPLATES_STORAGE_KEY, JSON.stringify(templates));
-  }, [hydrated, templates]);
-
-  useEffect(() => {
-    if (!hydrated) return;
-    safeWriteStorage(SELECTED_TEMPLATE_STORAGE_KEY, selectedId);
-  }, [hydrated, selectedId]);
-
   const flashSaveState = useCallback((state: 'saved' | 'error') => {
     if (saveTimer.current) window.clearTimeout(saveTimer.current);
     setSaveState(state);
     saveTimer.current = window.setTimeout(() => setSaveState('idle'), 1500);
   }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    const ok = safeWriteStorage(TEMPLATES_STORAGE_KEY, JSON.stringify(templates));
+    // Schedule on next tick so this setState goes through React's batching,
+    // avoiding the react-hooks/set-state-in-effect lint rule (see useMaintainerMode.ts).
+    if (!ok) {
+      const t = window.setTimeout(() => flashSaveState('error'), 0);
+      return () => window.clearTimeout(t);
+    }
+  }, [hydrated, templates, flashSaveState]);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    const ok = safeWriteStorage(SELECTED_TEMPLATE_STORAGE_KEY, selectedId);
+    if (!ok) {
+      const t = window.setTimeout(() => flashSaveState('error'), 0);
+      return () => window.clearTimeout(t);
+    }
+  }, [hydrated, selectedId, flashSaveState]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
Fixes #1083: the Reporting Templates settings page (`apps/web/src/app/create-reporting-templates-page-60.tsx`) autosaves silently swallowed `localStorage` write failures (e.g. `QuotaExceededError`). The UI kept showing "Autosaved" even when nothing was actually persisted.

## What changed
- `safeWriteStorage()` now returns a boolean instead of swallowing the error
- Both autosave effects (templates + selected template) now trigger the existing (previously unwired) "Save failed" badge when a write fails
- Exported `isQuotaExceededError`/`safeWriteStorage` for testability
- Added `create-reporting-templates-page-60.test.ts` covering quota detection and that a failed write is reported rather than thrown

## Verification
- [x] `npx tsc` on the changed files compiles with 0 errors
- [x] `npx eslint` on the changed files: 0 errors
- [x] New unit test passes (quota-exceeded detection + safeWriteStorage failure reporting)
- [x] Full-repo `tsc --noEmit` shows no new errors introduced by this change (pre-existing unrelated test-infra errors elsewhere are untouched)

Closes #1083
