### PR TITLE
fix(web): eliminate 800ms loading flash on log viewer page

### DIFF
--- a/apps/web/src/app/logs/page.tsx
+++ b/apps/web/src/app/logs/page.tsx
@@ -85,8 +85,8 @@ function EmptyState() {
 // Main page
 // ---------------------------------------------------------------------------
 export default function LogViewerPage() {
-  const [dataState, setDataState] = useState<PageDataState>('loading');
-  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [dataState, setDataState] = useState<PageDataState>('success');
+  const [entries, setEntries] = useState<LogEntry[]>(MOCK_LOG_ENTRIES);
   const [levelFilter, setLevelFilter] = useState<LogLevelFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearchQuery = useDebounce(searchQuery, 300);


### PR DESCRIPTION
Closes #1070

## Problem

When navigating to the Log Viewer page (`/logs`), users see an empty loading skeleton for ~800ms before the mock log data appears. The page component starts with `dataState = 'loading'` and an empty `entries` array, then `fetchLogs()` introduces an artificial 800ms delay via `setTimeout` before resolving with `MOCK_LOG_ENTRIES`.

This creates a visible flash of empty/loading state on every page visit, which degrades the user experience — especially jarring since the data is static mock data that could be rendered immediately.

## Root Cause

In `apps/web/src/app/logs/page.tsx`:

```tsx
// Page starts in loading state with empty data
const [dataState, setDataState] = useState<PageDataState>('loading');
const [entries, setEntries] = useState<LogEntry[]>([]);

// fetchLogs() waits 800ms before returning static mock data
async function fetchLogs(): Promise<LogEntry[]> {
  await new Promise((r) => setTimeout(r, 800));
  return MOCK_LOG_ENTRIES;
}
```

## Solution

Seed the initial component state with `MOCK_LOG_ENTRIES` and start in `'success'` state so the log table renders immediately on first paint:

```tsx
const [dataState, setDataState] = useState<PageDataState>('success');
const [entries, setEntries] = useState<LogEntry[]>(MOCK_LOG_ENTRIES);
```

The `useEffect` still calls `fetchLogs()` on mount and after retry, which will overwrite the seeded data with the same entries after the simulated delay. This preserves:
- The retry/error flow (clicking Retry sets state back to `'loading'`, re-triggers fetch)
- The simulated API delay behavior for when a real backend replaces the mock
- All existing filtering, search, and keyboard navigation behavior

## Changes

- `apps/web/src/app/logs/page.tsx`: Changed initial state from `loading`/empty to `success`/`MOCK_LOG_ENTRIES` (2 lines)

## Verification

- **Lint**: `npm run lint` — 0 errors
- **Build**: `npm run build` — compiles successfully
- **Tests**: `npm test` — all tests pass (including log-viewer-page-utils and log-viewer-utils)
- Log table renders immediately on page load — no 800ms loading skeleton flash
- Retry flow still works: clicking Retry shows loading skeleton, then re-fetches
- Filtering, search, keyboard navigation all unaffected
- Works in both light and dark mode
- Responsive on mobile viewports