### PR TITLE
[#1084] Settings: add Network Configuration page with on-blur RPC/Horizon URL validation

### DIFF
--- a/apps/web/src/app/settings/network/page.test.ts
+++ b/apps/web/src/app/settings/network/page.test.ts
@@ -1,0 +1,40 @@
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const appRoot = path.resolve(__dirname);
+const candidateComponentPaths = [
+  path.resolve(appRoot, 'page.tsx'),
+  path.resolve(process.cwd(), 'src/app/settings/network/page.tsx'),
+];
+
+const componentPath = candidateComponentPaths.find((candidatePath) =>
+  fs.existsSync(candidatePath),
+);
+
+const runAssertions = (): void => {
+  if (!componentPath) {
+    throw new Error(
+      `Component file not found. Checked: ${candidateComponentPaths.join(', ')}`,
+    );
+  }
+
+  const content = fs.readFileSync(componentPath, 'utf-8');
+
+  assert.ok(
+    content.includes("import NetworkConfigForm from '../../../components/NetworkConfigForm'"),
+    'Page should import the NetworkConfigForm component',
+  );
+  assert.ok(
+    content.includes('export default function NetworkSettingsPage()'),
+    'Page should export a default page component',
+  );
+  assert.ok(
+    content.includes('<NetworkConfigForm />'),
+    'Page should render the NetworkConfigForm component',
+  );
+
+  console.log('settings/network/page.test.ts: all assertions passed');
+};
+
+runAssertions();

--- a/apps/web/src/app/settings/network/page.tsx
+++ b/apps/web/src/app/settings/network/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import NetworkConfigForm from '../../../components/NetworkConfigForm';
+
+export default function NetworkSettingsPage() {
+  return (
+    <div className="px-6 md:px-8 max-w-5xl mx-auto w-full py-14">
+      <NetworkConfigForm />
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -46,6 +46,7 @@ export default function SettingsPage() {
           { href: '/settings/accessibility', title: 'Accessibility', desc: 'Keyboard navigation, screen reader and contrast settings', icon: '◈' },
           { href: '/settings/api', title: 'API Configuration', desc: 'Backend URL, rate limits and connection settings', icon: '⚙' },
           { href: '/settings/notifications', title: 'Notifications', desc: 'Configure notification types, delivery and quiet hours', icon: '◉' },
+          { href: '/settings/network', title: 'Network', desc: 'Manage Stellar RPC and Horizon network endpoints', icon: '◎' },
         ].map((item) => (
           <Link key={item.href} href={item.href} className="card card-padding card-interactive flex items-start gap-3 sm:gap-4 text-decoration-none">
             <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-lg flex items-center justify-center text-base sm:text-lg flex-shrink-0" style={{ background: '#E7F0F9', color: '#0A66C2' }}>

--- a/apps/web/src/components/NetworkConfigForm.tsx
+++ b/apps/web/src/components/NetworkConfigForm.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type { NetworkConfig } from '../app/network-config-utils';
+import { getNetworkFieldError, type NetworkFormField } from './network-config-form-utils';
+
+interface FormState {
+  name: string;
+  networkPassphrase: string;
+  horizonUrl: string;
+  rpcUrl: string;
+  friendbotUrl: string;
+}
+
+const EMPTY_FORM: FormState = {
+  name: '',
+  networkPassphrase: '',
+  horizonUrl: '',
+  rpcUrl: '',
+  friendbotUrl: '',
+};
+
+const FIELDS: { field: NetworkFormField; label: string; placeholder: string }[] = [
+  { field: 'name', label: 'Network Name', placeholder: 'My Custom Network' },
+  {
+    field: 'networkPassphrase',
+    label: 'Network Passphrase',
+    placeholder: 'Test SDF Network ; September 2015',
+  },
+  { field: 'horizonUrl', label: 'Horizon URL', placeholder: 'https://horizon-testnet.stellar.org' },
+  { field: 'rpcUrl', label: 'RPC URL', placeholder: 'https://soroban-testnet.stellar.org' },
+  {
+    field: 'friendbotUrl',
+    label: 'Friendbot URL (optional)',
+    placeholder: 'https://friendbot.stellar.org',
+  },
+];
+
+const dangerStyle = { color: '#CC1016' };
+const successStyle = { color: '#057642' };
+
+export default function NetworkConfigForm() {
+  const [networks, setNetworks] = useState<NetworkConfig[]>([]);
+  const [activeNetworkId, setActiveNetworkId] = useState<string>('');
+  const [listLoading, setListLoading] = useState(true);
+  const [listError, setListError] = useState<string | null>(null);
+
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [touched, setTouched] = useState<Partial<Record<NetworkFormField, boolean>>>({});
+  const [errors, setErrors] = useState<Partial<Record<NetworkFormField, string>>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<'idle' | 'saved' | 'error'>('idle');
+  const [submitting, setSubmitting] = useState(false);
+
+  const loadNetworks = useCallback(async () => {
+    setListLoading(true);
+    setListError(null);
+    try {
+      const res = await fetch('/api/networks');
+      const json = await res.json();
+      if (!res.ok) {
+        setListError(json?.error ?? 'Failed to load networks.');
+        return;
+      }
+      setNetworks(json.data.networks ?? []);
+      setActiveNetworkId(json.data.activeNetworkId ?? '');
+    } catch {
+      setListError('Failed to load networks. Check your connection and try again.');
+    } finally {
+      setListLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      void loadNetworks();
+    });
+  }, [loadNetworks]);
+
+  const handleChange = useCallback((field: NetworkFormField, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setSaveState('idle');
+    // Re-validate immediately if the field has already been blurred once,
+    // so corrections are reflected without needing another blur.
+    setErrors((prev) => {
+      if (!prev[field] && !touched[field]) return prev;
+      const error = getNetworkFieldError(field, value);
+      return { ...prev, [field]: error ?? undefined };
+    });
+  }, [touched]);
+
+  const handleBlur = useCallback((field: NetworkFormField) => {
+    setTouched((prev) => ({ ...prev, [field]: true }));
+    setErrors((prev) => ({
+      ...prev,
+      [field]: getNetworkFieldError(field, form[field]) ?? undefined,
+    }));
+  }, [form]);
+
+  const validateAll = useCallback((): Partial<Record<NetworkFormField, string>> => {
+    const next: Partial<Record<NetworkFormField, string>> = {};
+    for (const { field } of FIELDS) {
+      const error = getNetworkFieldError(field, form[field]);
+      if (error) next[field] = error;
+    }
+    return next;
+  }, [form]);
+
+  const hasErrors = useMemo(
+    () => Object.values(errors).some(Boolean),
+    [errors],
+  );
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setSubmitError(null);
+
+      const allErrors = validateAll();
+      setErrors(allErrors);
+      setTouched({
+        name: true,
+        networkPassphrase: true,
+        horizonUrl: true,
+        rpcUrl: true,
+        friendbotUrl: true,
+      });
+
+      if (Object.keys(allErrors).length > 0) return;
+
+      setSubmitting(true);
+      try {
+        const payload: Record<string, string> = {
+          name: form.name.trim(),
+          networkPassphrase: form.networkPassphrase.trim(),
+          horizonUrl: form.horizonUrl.trim(),
+          rpcUrl: form.rpcUrl.trim(),
+        };
+        if (form.friendbotUrl.trim()) {
+          payload.friendbotUrl = form.friendbotUrl.trim();
+        }
+
+        const res = await fetch('/api/networks', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const json = await res.json();
+
+        if (!res.ok) {
+          setSubmitError(json?.error ?? 'Failed to add network.');
+          setSaveState('error');
+          return;
+        }
+
+        setForm(EMPTY_FORM);
+        setTouched({});
+        setErrors({});
+        setSaveState('saved');
+        await loadNetworks();
+      } catch {
+        setSubmitError('Failed to add network. Check your connection and try again.');
+        setSaveState('error');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [form, validateAll, loadNetworks],
+  );
+
+  const setActive = useCallback(
+    async (id: string) => {
+      try {
+        const res = await fetch('/api/networks/active', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id }),
+        });
+        if (res.ok) {
+          await loadNetworks();
+        }
+      } catch {
+        // Network list refresh will simply retain the previous active id;
+        // the user can retry from the list.
+      }
+    },
+    [loadNetworks],
+  );
+
+  const deleteNetwork = useCallback(
+    async (id: string, name: string) => {
+      const ok = window.confirm(`Remove network "${name}"? This cannot be undone.`);
+      if (!ok) return;
+      try {
+        const res = await fetch(`/api/networks/${id}`, { method: 'DELETE' });
+        if (res.ok) {
+          await loadNetworks();
+        }
+      } catch {
+        // Leave the list as-is; the user can retry.
+      }
+    },
+    [loadNetworks],
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="heading-page">Network Configuration</h1>
+        <p className="text-meta mt-1">
+          Manage Stellar network endpoints (Horizon and RPC URLs) used to connect to mainnet,
+          testnet, futurenet, or a custom network.
+        </p>
+      </div>
+
+      <div className="card card-padding">
+        <h3 className="font-semibold text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
+          Configured Networks
+        </h3>
+
+        {listLoading && (
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="skeleton h-5 rounded" />
+            ))}
+          </div>
+        )}
+
+        {!listLoading && listError && (
+          <p className="text-sm" style={dangerStyle}>
+            {listError}
+          </p>
+        )}
+
+        {!listLoading && !listError && (
+          <div className="space-y-2">
+            {networks.map((network) => (
+              <div key={network.id} className="flex items-center justify-between py-2 gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                    {network.name}
+                    {network.id === activeNetworkId && (
+                      <span className="ml-2 text-xs font-semibold" style={successStyle}>
+                        Active
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-meta text-xs truncate">{network.rpcUrl}</p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  {network.id !== activeNetworkId && (
+                    <button
+                      type="button"
+                      className="btn-outline"
+                      style={{ height: '30px', fontSize: '12px', padding: '0 10px' }}
+                      onClick={() => setActive(network.id)}
+                    >
+                      Set active
+                    </button>
+                  )}
+                  {!network.isBuiltIn && (
+                    <button
+                      type="button"
+                      className="btn-outline"
+                      style={{ height: '30px', fontSize: '12px', padding: '0 10px', ...dangerStyle }}
+                      onClick={() => deleteNetwork(network.id, network.name)}
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <form
+        id="network-config-form"
+        className="card card-padding space-y-5"
+        noValidate
+        onSubmit={handleSubmit}
+      >
+        <h3 className="font-semibold text-sm" style={{ color: 'var(--text-secondary)' }}>
+          Add Network
+        </h3>
+
+        {FIELDS.map(({ field, label, placeholder }) => (
+          <div key={field}>
+            <label htmlFor={`network-${field}`} className="input-label">
+              {label}
+            </label>
+            <input
+              id={`network-${field}`}
+              className="input-field mt-1"
+              placeholder={placeholder}
+              value={form[field]}
+              onChange={(e) => handleChange(field, e.target.value)}
+              onBlur={() => handleBlur(field)}
+            />
+            {touched[field] && errors[field] && (
+              <p className="text-xs mt-1" style={dangerStyle}>
+                {errors[field]}
+              </p>
+            )}
+          </div>
+        ))}
+
+        {submitError && (
+          <p className="text-sm" style={dangerStyle}>
+            {submitError}
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          {saveState === 'saved' && (
+            <span className="text-sm font-semibold" style={successStyle}>
+              Added
+            </span>
+          )}
+          <button
+            id="network-config-save"
+            type="submit"
+            className="btn-primary"
+            disabled={submitting || (hasErrors && Object.values(touched).some(Boolean))}
+            style={{ height: '36px', fontSize: '14px', padding: '0 20px' }}
+          >
+            {submitting ? 'Adding…' : 'Add network'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/network-config-form-utils.test.ts
+++ b/apps/web/src/components/network-config-form-utils.test.ts
@@ -1,0 +1,82 @@
+import * as assert from 'node:assert/strict';
+import { getNetworkFieldError } from './network-config-form-utils';
+
+// name
+assert.equal(getNetworkFieldError('name', ''), 'Name is required.');
+assert.equal(getNetworkFieldError('name', '   '), 'Name is required.');
+assert.equal(getNetworkFieldError('name', 'My Network'), null);
+assert.equal(
+  getNetworkFieldError('name', 'a'.repeat(65)),
+  'Name must be 64 characters or fewer.',
+);
+assert.equal(
+  getNetworkFieldError('name', ' My Network'),
+  'Name must not have leading or trailing whitespace.',
+);
+
+// networkPassphrase
+assert.equal(
+  getNetworkFieldError('networkPassphrase', ''),
+  'Network passphrase is required.',
+);
+assert.equal(
+  getNetworkFieldError('networkPassphrase', 'Test SDF Network ; September 2015'),
+  null,
+);
+
+// horizonUrl
+assert.equal(getNetworkFieldError('horizonUrl', ''), 'Horizon URL is required.');
+assert.equal(
+  getNetworkFieldError('horizonUrl', 'not a url'),
+  'Horizon URL is not a valid URL.',
+);
+assert.equal(
+  getNetworkFieldError('horizonUrl', 'https://horizon-testnet.stellar.org'),
+  null,
+);
+
+// rpcUrl — this is the core bug from issue #1084: the form must reject
+// malformed RPC URLs on blur, using the same rules already enforced
+// server-side by validateNetworkUrl().
+assert.equal(getNetworkFieldError('rpcUrl', ''), 'RPC URL is required.');
+assert.equal(
+  getNetworkFieldError('rpcUrl', 'not-a-url'),
+  'RPC URL is not a valid URL.',
+);
+assert.equal(
+  getNetworkFieldError('rpcUrl', 'ftp://example.com/rpc'),
+  'RPC URL must use HTTP or HTTPS protocol.',
+);
+assert.equal(
+  getNetworkFieldError('rpcUrl', 'http://example.com/rpc'),
+  'RPC URL must use HTTPS (HTTP is only allowed for localhost).',
+);
+assert.equal(
+  getNetworkFieldError('rpcUrl', 'http://localhost:8000/rpc'),
+  null,
+);
+assert.equal(
+  getNetworkFieldError('rpcUrl', 'https://soroban-testnet.stellar.org'),
+  null,
+);
+assert.equal(
+  getNetworkFieldError('rpcUrl', 'https://mainnet.stellar.validationcloud.io/v1/xycxyc'),
+  null,
+);
+assert.equal(
+  getNetworkFieldError('rpcUrl', 'https://example.com/unexpected-path'),
+  'RPC URL must have a valid path format (e.g., /, /v1/key, /rpc).',
+);
+
+// friendbotUrl — optional
+assert.equal(getNetworkFieldError('friendbotUrl', ''), null);
+assert.equal(
+  getNetworkFieldError('friendbotUrl', 'not a url'),
+  'Friendbot URL is not a valid URL.',
+);
+assert.equal(
+  getNetworkFieldError('friendbotUrl', 'https://friendbot.stellar.org'),
+  null,
+);
+
+console.log('network-config-form-utils.test.ts: all assertions passed');

--- a/apps/web/src/components/network-config-form-utils.ts
+++ b/apps/web/src/components/network-config-form-utils.ts
@@ -1,0 +1,46 @@
+import { validateNetworkUrl } from '../app/network-config-utils';
+
+export type NetworkFormField =
+  | 'name'
+  | 'networkPassphrase'
+  | 'horizonUrl'
+  | 'rpcUrl'
+  | 'friendbotUrl';
+
+/**
+ * Returns a validation error message for a single network form field, or
+ * null if the value is valid. Kept separate from the form component so it
+ * can be unit tested without rendering React/DOM.
+ */
+export function getNetworkFieldError(
+  field: NetworkFormField,
+  value: string,
+): string | null {
+  switch (field) {
+    case 'name': {
+      if (!value.trim()) return 'Name is required.';
+      if (value.length > 64) return 'Name must be 64 characters or fewer.';
+      if (value !== value.trim()) {
+        return 'Name must not have leading or trailing whitespace.';
+      }
+      return null;
+    }
+
+    case 'networkPassphrase':
+      return value.trim() ? null : 'Network passphrase is required.';
+
+    case 'horizonUrl':
+      return validateNetworkUrl(value, 'Horizon URL');
+
+    case 'rpcUrl':
+      return validateNetworkUrl(value, 'RPC URL');
+
+    case 'friendbotUrl':
+      // Friendbot URL is optional; only validate format if something was entered.
+      if (!value.trim()) return null;
+      return validateNetworkUrl(value, 'Friendbot URL');
+
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
Closes #1084. That issue described a bug in a Network Configuration form, but no such form existed in the codebase yet — only the backend validation logic (`network-config-utils.ts`, already correct and unit-tested) and API routes (`api/networks/*`) were present. This PR adds the missing Settings → Network page and wires up on-blur validation.

## What changed
- `NetworkConfigForm.tsx`: lists configured networks (set active / remove) and a form to add a new one (name, passphrase, Horizon URL, RPC URL, optional Friendbot URL)
- Each field validates **on blur** via `getNetworkFieldError()`, which wraps the existing `validateNetworkUrl()`/`validateNetworkConfig()` rules — this is the core of #1084: RPC URL format (protocol, HTTPS-except-localhost, path shape) is now caught immediately on blur with an inline error, instead of only being caught server-side on submit
- `settings/network/page.tsx`: new page, added to the Settings index (matching the existing alerting/reporting/accessibility/api/notifications cards)
- `network-config-form-utils.ts` (+test): pure, DOM-free field-validation helper so the on-blur logic is unit testable without rendering React
- `settings/network/page.test.ts`: content-based test matching the existing `settings/api/page.test.ts` convention

## Verification
- [x] New unit tests pass (`network-config-form-utils.test.ts`, `page.test.ts`)
- [x] `tsc` on all changed/added files: 0 errors
- [x] `eslint` on all changed/added files: 0 errors
- [x] Full-project `tsc --noEmit`: no errors attributable to this change
- [ ] `npm run build` — currently fails at `implement-run-history-table-component.tsx:227` (`Cannot find name 'sortField'`). Confirmed this is **pre-existing on a clean `upstream/main` checkout** with none of this PR's changes applied, so it's unrelated to this fix. Happy to help fix that separately if useful.

Closes #1084
