### PR TITLE
[#1089] integration: implement GitHub issue link resolver adapter

### DIFF
--- a/apps/web/src/app/api/integrations/github-issue/route.ts
+++ b/apps/web/src/app/api/integrations/github-issue/route.ts
@@ -1,0 +1,40 @@
+/**
+ * GET /api/integrations/github-issue?url=<github issue url>
+ *
+ * Resolves a GitHub issue URL to its real title/state via GitHub's public
+ * REST API, for use by the "Run Issue Links" UI. Runs server-side so the
+ * browser never has to make a cross-origin call directly and so repeated
+ * lookups from many clients share GitHub's public (unauthenticated) rate
+ * limit sensibly rather than each browser session burning its own.
+ *
+ * Never requires a token: unauthenticated reads of public repository
+ * issues are all this needs. If resolution fails for any reason (private
+ * repo, deleted issue, rate limited, network error), this returns a 200
+ * with `resolved: false` and a placeholder title rather than an error
+ * status, since "couldn't get a nicer title" isn't a failure of the
+ * request itself.
+ */
+
+import { NextRequest } from 'next/server';
+import { parseGithubIssueUrl, resolveGithubIssueLink } from '@/lib/integrations/github-issues';
+import { successResponse } from '@/lib/api-response-utils';
+import { jsonError, withRouteErrorHandling } from '@/lib/route-handler';
+
+export const GET = withRouteErrorHandling(
+  'GET /api/integrations/github-issue',
+  async (request: NextRequest) => {
+    const url = request.nextUrl.searchParams.get('url');
+
+    if (!url) {
+      return jsonError('Query parameter "url" is required.', 400);
+    }
+
+    const parsed = parseGithubIssueUrl(url);
+    if (!parsed) {
+      return jsonError('Not a recognizable GitHub issue or pull request URL.', 400);
+    }
+
+    const issue = await resolveGithubIssueLink(parsed.owner, parsed.repo, parsed.issueNumber);
+    return successResponse({ issue });
+  },
+);

--- a/apps/web/src/app/create-run-issue-link-page-page.tsx
+++ b/apps/web/src/app/create-run-issue-link-page-page.tsx
@@ -78,7 +78,11 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
     href: ''
   });
   const [isAddingIssue, setIsAddingIssue] = useState(false);
-  
+
+  const [isResolvingTitle, setIsResolvingTitle] = useState(false);
+  const [resolveNotice, setResolveNotice] = useState<string | null>(null);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -93,6 +97,8 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
     setIsAddingIssue(false);
     setError(null);
     setSaveSuccess(false);
+    setResolveNotice(null);
+    setResolveError(null);
   }, [runs]);
 
   const handleAddIssue = useCallback(() => {
@@ -113,6 +119,8 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
     setFormData({ label: '', href: '' });
     setIsAddingIssue(false);
     setError(null);
+    setResolveNotice(null);
+    setResolveError(null);
   }, [formData, issueLinks]);
 
   const handleRemoveIssue = useCallback((index: number) => {
@@ -150,7 +158,46 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
     if (field === 'href' && error === 'Invalid URL format') {
       setError(null);
     }
+    if (field === 'href') {
+      setResolveNotice(null);
+      setResolveError(null);
+    }
   }, [error]);
+
+  const handleIssueUrlBlur = useCallback(async () => {
+    const href = formData.href.trim();
+    if (!href || !validateIssueUrl(href) || getIssueTypeFromUrl(href) !== 'GitHub Issue') {
+      return;
+    }
+    // Don't overwrite a label the user already typed.
+    if (formData.label.trim()) return;
+
+    setIsResolvingTitle(true);
+    setResolveNotice(null);
+    setResolveError(null);
+
+    try {
+      const res = await fetch(`/api/integrations/github-issue?url=${encodeURIComponent(href)}`);
+      const json = await res.json();
+
+      if (!res.ok) {
+        setResolveError(json?.error ?? 'Could not look up this issue automatically.');
+        return;
+      }
+
+      const issue = json?.data?.issue as { title?: string; resolved?: boolean } | undefined;
+      if (issue?.resolved && issue.title) {
+        setFormData(prev => (prev.href === href && !prev.label.trim() ? { ...prev, label: issue.title as string } : prev));
+        setResolveNotice('Title filled in automatically from GitHub.');
+      } else {
+        setResolveError('Could not fetch a title automatically – enter one manually.');
+      }
+    } catch {
+      setResolveError('Could not reach GitHub to look up this issue – enter a title manually.');
+    } finally {
+      setIsResolvingTitle(false);
+    }
+  }, [formData.href, formData.label]);
 
   const isFormValid = formData.label.trim() && formData.href.trim() && validateIssueUrl(formData.href);
 
@@ -273,6 +320,9 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
                       type="url"
                       value={formData.href}
                       onChange={(e) => handleFormChange('href', e.target.value)}
+                      onBlur={() => {
+                        void handleIssueUrlBlur();
+                      }}
                       placeholder="https://github.com/user/repo/issues/123"
                       className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
                         formData.href && !validateIssueUrl(formData.href)
@@ -284,6 +334,21 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
                     />
                     {formData.href && !validateIssueUrl(formData.href) && (
                       <p className="text-xs text-red-600 mt-1">Please enter a valid URL (http/https)</p>
+                    )}
+                    {isResolvingTitle && (
+                      <p className="text-xs text-gray-500 mt-1" role="status">
+                        Looking up issue title from GitHub…
+                      </p>
+                    )}
+                    {!isResolvingTitle && resolveNotice && (
+                      <p className="text-xs text-green-700 mt-1" role="status">
+                        {resolveNotice}
+                      </p>
+                    )}
+                    {!isResolvingTitle && resolveError && (
+                      <p className="text-xs text-yellow-700 mt-1" role="status">
+                        {resolveError}
+                      </p>
                     )}
                   </div>
                   <div className="flex gap-2">
@@ -299,6 +364,8 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
                         setIsAddingIssue(false);
                         setFormData({ label: '', href: '' });
                         setError(null);
+                        setResolveNotice(null);
+                        setResolveError(null);
                       }}
                       className="px-3 py-1 text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50 text-sm focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1"
                     >

--- a/apps/web/src/lib/integrations/github-issues.test.ts
+++ b/apps/web/src/lib/integrations/github-issues.test.ts
@@ -1,0 +1,109 @@
+import * as assert from 'node:assert/strict';
+import {
+  parseGithubIssueUrl,
+  resolveGithubIssueLink,
+  resolveGithubIssueLinkFromUrl,
+} from './github-issues';
+
+type FetchImpl = typeof fetch;
+const originalFetch: FetchImpl | undefined = (globalThis as { fetch?: FetchImpl }).fetch;
+
+function setFetch(impl: FetchImpl): void {
+  (globalThis as { fetch?: FetchImpl }).fetch = impl;
+}
+
+function restoreFetch(): void {
+  (globalThis as { fetch?: FetchImpl }).fetch = originalFetch;
+}
+
+async function run(): Promise<void> {
+  // parseGithubIssueUrl
+  assert.deepEqual(
+    parseGithubIssueUrl('https://github.com/foo/bar/issues/123'),
+    { owner: 'foo', repo: 'bar', issueNumber: 123 },
+  );
+  assert.deepEqual(
+    parseGithubIssueUrl('https://github.com/foo/bar/issues/123/'),
+    { owner: 'foo', repo: 'bar', issueNumber: 123 },
+  );
+  assert.deepEqual(
+    parseGithubIssueUrl('https://www.github.com/foo/bar/pull/7'),
+    { owner: 'foo', repo: 'bar', issueNumber: 7 },
+  );
+  assert.equal(parseGithubIssueUrl('not a url'), null);
+  assert.equal(parseGithubIssueUrl('https://gitlab.com/foo/bar/issues/1'), null);
+  assert.equal(parseGithubIssueUrl('https://github.com/foo/bar'), null);
+  assert.equal(parseGithubIssueUrl('https://github.com/foo/bar/issues/abc'), null);
+  assert.equal(parseGithubIssueUrl('https://github.com/foo/bar/issues/0'), null);
+
+  // resolveGithubIssueLink — successful API response
+  setFetch((async () =>
+    new Response(JSON.stringify({ title: 'Fix crash in fuzzer', state: 'open' }), {
+      status: 200,
+    })) as unknown as FetchImpl);
+
+  const success = await resolveGithubIssueLink('foo', 'bar', 42);
+  assert.equal(success.url, 'https://github.com/foo/bar/issues/42');
+  assert.equal(success.title, 'Fix crash in fuzzer');
+  assert.equal(success.state, 'open');
+  assert.equal(success.resolved, true);
+
+  // resolveGithubIssueLink — closed issue
+  setFetch((async () =>
+    new Response(JSON.stringify({ title: 'Old bug', state: 'closed' }), {
+      status: 200,
+    })) as unknown as FetchImpl);
+
+  const closed = await resolveGithubIssueLink('foo', 'bar', 43);
+  assert.equal(closed.state, 'closed');
+  assert.equal(closed.resolved, true);
+
+  // resolveGithubIssueLink — 404 falls back gracefully, does not throw
+  setFetch((async () => new Response('Not Found', { status: 404 })) as unknown as FetchImpl);
+
+  const notFound = await resolveGithubIssueLink('foo', 'bar', 999);
+  assert.equal(notFound.url, 'https://github.com/foo/bar/issues/999');
+  assert.equal(notFound.title, '#999');
+  assert.equal(notFound.resolved, false);
+  assert.equal(notFound.state, undefined);
+
+  // resolveGithubIssueLink — network error falls back gracefully
+  setFetch((async () => {
+    throw new Error('network down');
+  }) as unknown as FetchImpl);
+
+  const networkError = await resolveGithubIssueLink('foo', 'bar', 5);
+  assert.equal(networkError.resolved, false);
+  assert.equal(networkError.title, '#5');
+
+  // resolveGithubIssueLink — malformed response body falls back gracefully
+  setFetch((async () =>
+    new Response(JSON.stringify({ notATitle: true }), { status: 200 })) as unknown as FetchImpl);
+
+  const malformed = await resolveGithubIssueLink('foo', 'bar', 6);
+  assert.equal(malformed.resolved, false);
+  assert.equal(malformed.title, '#6');
+
+  // resolveGithubIssueLinkFromUrl — non-GitHub-issue URL returns null
+  const notApplicable = await resolveGithubIssueLinkFromUrl('https://jira.example.com/ISSUE-1');
+  assert.equal(notApplicable, null);
+
+  // resolveGithubIssueLinkFromUrl — valid URL resolves end-to-end
+  setFetch((async () =>
+    new Response(JSON.stringify({ title: 'End to end', state: 'open' }), {
+      status: 200,
+    })) as unknown as FetchImpl);
+
+  const endToEnd = await resolveGithubIssueLinkFromUrl('https://github.com/foo/bar/issues/1');
+  assert.ok(endToEnd);
+  assert.equal(endToEnd?.title, 'End to end');
+
+  restoreFetch();
+  console.log('github-issues.test.ts: all assertions passed');
+}
+
+run().catch((error) => {
+  restoreFetch();
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/web/src/lib/integrations/github-issues.ts
+++ b/apps/web/src/lib/integrations/github-issues.ts
@@ -1,22 +1,121 @@
 /**
- * GitHub Issue Link Adapter (stub)
+ * GitHub Issue Link Adapter
  *
  * Small, dependency-free helper that resolves a GitHub issue link for use
- * in the UI. This is intentionally lightweight and works without a token.
+ * in the UI. Works without a token, using GitHub's public REST API for
+ * unauthenticated reads of public repositories. If the API is unreachable,
+ * rate-limited, or the issue/repo can't be found, this falls back to a
+ * canonical URL with a placeholder title rather than throwing - the caller
+ * should never have to handle an exception from this module.
  */
 
 export interface ResolvedIssueLink {
   url: string;
   title?: string;
+  state?: 'open' | 'closed';
+  resolved: boolean;
 }
 
-export async function resolveGithubIssueLink(owner: string, repo: string, issueNumber: number): Promise<ResolvedIssueLink> {
-  // Construct canonical GitHub issue URL. Consumers may later extend this to
-  // call the GitHub API for richer metadata.
-  return {
-    url: `https://github.com/${owner}/${repo}/issues/${issueNumber}`,
+export interface ParsedGithubIssueUrl {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+}
+
+/**
+ * Parses a GitHub issue (or pull request) URL into its owner/repo/number
+ * parts. Returns null if the URL isn't a recognizable GitHub issue link.
+ */
+export function parseGithubIssueUrl(url: string): ParsedGithubIssueUrl | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (parsed.hostname !== 'github.com' && parsed.hostname !== 'www.github.com') {
+    return null;
+  }
+
+  const match = parsed.pathname.match(
+    /^\/([^/]+)\/([^/]+)\/(?:issues|pull)\/(\d+)\/?$/,
+  );
+  if (!match) return null;
+
+  const [, owner, repo, issueNumberStr] = match;
+  const issueNumber = Number.parseInt(issueNumberStr, 10);
+  if (!Number.isFinite(issueNumber) || issueNumber <= 0) return null;
+
+  return { owner, repo, issueNumber };
+}
+
+function canonicalUrl(owner: string, repo: string, issueNumber: number): string {
+  return `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
+}
+
+/**
+ * Resolves a GitHub issue to its real title/state via the public REST API.
+ * Never throws: on any failure (network error, timeout, 404, rate limit,
+ * private repo) it falls back to a placeholder title, matching the
+ * previous stub behavior, with `resolved: false` so callers can tell the
+ * difference if they need to.
+ */
+export async function resolveGithubIssueLink(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<ResolvedIssueLink> {
+  const url = canonicalUrl(owner, repo, issueNumber);
+  const fallback: ResolvedIssueLink = {
+    url,
     title: `#${issueNumber}`,
+    resolved: false,
   };
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${issueNumber}`,
+      {
+        headers: { Accept: 'application/vnd.github+json' },
+        signal: AbortSignal.timeout?.(8_000),
+      },
+    );
+
+    if (!response.ok) {
+      return fallback;
+    }
+
+    const data = (await response.json()) as { title?: unknown; state?: unknown };
+    if (typeof data.title !== 'string' || !data.title) {
+      return fallback;
+    }
+
+    return {
+      url,
+      title: data.title,
+      state: data.state === 'closed' ? 'closed' : 'open',
+      resolved: true,
+    };
+  } catch {
+    // Network error, timeout, or unexpected response shape - degrade
+    // gracefully rather than surfacing an error to the caller.
+    return fallback;
+  }
+}
+
+/**
+ * Convenience wrapper: parses a raw GitHub issue URL and resolves it in one
+ * step. Returns null if the URL isn't a GitHub issue link at all (caller
+ * should treat that as "not applicable", distinct from a resolution
+ * failure which still returns a fallback ResolvedIssueLink).
+ */
+export async function resolveGithubIssueLinkFromUrl(
+  url: string,
+): Promise<ResolvedIssueLink | null> {
+  const parsed = parseGithubIssueUrl(url);
+  if (!parsed) return null;
+  return resolveGithubIssueLink(parsed.owner, parsed.repo, parsed.issueNumber);
 }
 
 


### PR DESCRIPTION
## Summary
Closes #1089. `lib/integrations/github-issues.ts` was a stub — `resolveGithubIssueLink()` just echoed back a canonical URL and a `#N` placeholder title without ever calling GitHub, and nothing in the app actually used it. This implements the adapter for real and wires it into the existing **Run Issue Links** feature.

## What changed
- `parseGithubIssueUrl()`: parses a raw GitHub issue/PR URL into owner/repo/issueNumber, or `null` if it isn't a GitHub issue link
- `resolveGithubIssueLink()`: now fetches the real title/state from GitHub's public REST API (no token required — unauthenticated reads of public repos), with an 8s timeout. **Never throws**: on any failure (404, rate limit, network error, malformed response) it falls back to the original placeholder behavior with `resolved: false`
- `resolveGithubIssueLinkFromUrl()`: convenience wrapper combining both
- New route `GET /api/integrations/github-issue?url=...` so the lookup runs server-side, following the same fetch+timeout+graceful-fallback pattern already used by the PagerDuty test-connection adapter
- Wired into `create-run-issue-link-page-page.tsx`: entering a GitHub issue URL and blurring the field (with no label typed yet) auto-fills the label with the real issue title. Added loading / success / error-or-empty inline states so a failed lookup never blocks manually typing a label
- `github-issues.test.ts`: covers URL parsing, successful resolution, closed issues, 404s, network errors, and malformed responses (mocked `fetch`)

## Verification
- [x] New unit tests pass (`github-issues.test.ts`)
- [x] Existing `run-issue-utils.test.ts` still passes, untouched
- [x] `tsc` on all changed/added files: 0 errors
- [x] Full-project `tsc --noEmit`: no errors attributable to this change
- [x] `eslint` on all changed/added files: 0 errors
- [ ] `npm run build` — note: this currently fails on a clean `main` checkout at `implement-run-history-table-component.tsx:227` (`Cannot find name 'sortField'`), unrelated to this change (see #1250 for prior confirmation of the same pre-existing issue)

Closes #1089
