### PR TITLE
fix: resolves issue #1124 - Add fuzzy search across all run fields with ranking

### DIFF
--- a/apps/web/src/app/create-fuzzy-search-page.tsx
+++ b/apps/web/src/app/create-fuzzy-search-page.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { fetchRuns } from '../lib/api-client';
+import { FuzzingRun } from './types';
+import { fuzzySearch, getSearchableFieldLabels, type FuzzySearchResult } from './fuzzy-search-utils';
+
+type PageState = 'loading' | 'success' | 'error';
+
+function LoadingSkeleton() {
+  return (
+    <div role="status" aria-label="Loading" className="space-y-4 animate-pulse">
+      <div className="h-10 w-full max-w-md rounded-xl bg-zinc-200 dark:bg-zinc-800" />
+      <div className="h-64 rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-zinc-100 dark:bg-zinc-900" />
+    </div>
+  );
+}
+
+export default function CreateFuzzySearchPage() {
+  const [pageState, setPageState] = useState<PageState>('loading');
+  const [runs, setRuns] = useState<FuzzingRun[]>([]);
+  const [query, setQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<FuzzySearchResult[]>([]);
+  const [showFieldHelp, setShowFieldHelp] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchRuns()
+      .then((data) => {
+        if (!cancelled) {
+          setRuns(data.runs ?? []);
+          setPageState('success');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setPageState('error');
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleSearch = useCallback((value: string) => {
+    setQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => {
+      setSearchResults(fuzzySearch(runs, value));
+    }, 150);
+  }, [runs]);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const fieldLabels = useMemo(() => getSearchableFieldLabels(), []);
+
+  const handleRetry = useCallback(() => {
+    setPageState('loading');
+    fetchRuns()
+      .then((data) => {
+        setRuns(data.runs ?? []);
+        setPageState('success');
+      })
+      .catch(() => setPageState('error'));
+  }, []);
+
+  return (
+    <div className="container-full page-padding fade-in">
+      <div className="mb-6">
+        <h1 className="heading-page">Fuzzy Search</h1>
+        <p className="text-meta mt-1 text-sm">
+          Search across all run fields with relevance-based ranking.
+        </p>
+      </div>
+
+      {pageState === 'loading' && <LoadingSkeleton />}
+
+      {pageState === 'error' && (
+        <div role="alert" className="card card-padding text-center py-12">
+          <p className="text-rose-600 dark:text-rose-400 font-semibold">Failed to load runs</p>
+          <p className="text-meta mt-1 mb-4 text-sm">Check your connection and try again.</p>
+          <button type="button" onClick={handleRetry} className="btn-primary text-sm">
+            Retry
+          </button>
+        </div>
+      )}
+
+      {pageState === 'success' && (
+        <div className="space-y-4">
+          <div className="relative">
+            <div className="relative">
+              <svg
+                className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-zinc-400 dark:text-zinc-500"
+                fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <input
+                ref={inputRef}
+                type="search"
+                value={query}
+                onChange={(e) => handleSearch(e.target.value)}
+                placeholder="Search runs by ID, status, area, signature, tags..."
+                className="w-full pl-12 pr-4 py-3 rounded-xl border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-sm focus:outline-none focus:ring-2 focus:ring-[#0A66C2]"
+                autoFocus
+                aria-label="Search runs"
+              />
+            </div>
+            <div className="flex items-center justify-between mt-2 text-xs text-meta">
+              <span>{runs.length} runs indexed</span>
+              <button
+                type="button"
+                onClick={() => setShowFieldHelp(!showFieldHelp)}
+                className="underline hover:text-[var(--text-primary)]"
+              >
+                {showFieldHelp ? 'Hide' : 'Show'} searchable fields
+              </button>
+            </div>
+            {showFieldHelp && (
+              <div className="mt-2 p-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
+                <div className="text-xs font-semibold text-zinc-600 dark:text-zinc-400 mb-2">Searchable Fields:</div>
+                <div className="flex flex-wrap gap-1.5">
+                  {fieldLabels.map((label) => (
+                    <span key={label} className="px-2 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 text-[11px] font-medium">
+                      {label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {query.trim() === '' ? (
+            <div className="card card-padding text-center py-12">
+              <div className="text-3xl mb-3 opacity-30">🔍</div>
+              <p className="text-meta text-sm">Type a search term to find runs.</p>
+              <p className="text-xs text-meta mt-1">Fuzzy matching supports typos and partial matches.</p>
+            </div>
+          ) : searchResults.length === 0 ? (
+            <div className="card card-padding text-center py-12">
+              <p className="text-meta text-sm">No runs match &ldquo;{query}&rdquo;</p>
+              <p className="text-xs text-meta mt-1">Try a different search term.</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-meta">
+                  Found <strong>{searchResults.length}</strong> {searchResults.length === 1 ? 'result' : 'results'}
+                </p>
+              </div>
+              <div className="space-y-2">
+                {searchResults.slice(0, 50).map((result) => (
+                  <div
+                    key={result.run.id}
+                    className="card card-padding card-interactive"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="font-mono text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+                            {result.run.id}
+                          </span>
+                          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                            result.run.status === 'completed' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' :
+                            result.run.status === 'failed' ? 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300' :
+                            result.run.status === 'running' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300' :
+                            'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400'
+                          }`}>
+                            {result.run.status}
+                          </span>
+                          <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                            {result.run.area}
+                          </span>
+                          <span className={`text-xs font-medium ${
+                            result.run.severity === 'critical' ? 'text-rose-600 dark:text-rose-400' :
+                            result.run.severity === 'high' ? 'text-orange-600 dark:text-orange-400' :
+                            result.run.severity === 'medium' ? 'text-amber-600 dark:text-amber-400' :
+                            'text-emerald-600 dark:text-emerald-400'
+                          }`}>
+                            {result.run.severity}
+                          </span>
+                        </div>
+                        {result.matchedFields.length > 0 && (
+                          <div className="flex flex-wrap gap-1.5 mt-1.5">
+                            {result.matchedFields.slice(0, 4).map((field) => (
+                              <span key={field.field} className="text-[11px] px-2 py-0.5 rounded-full bg-[#E7F0F9] text-[#0A66C2] dark:bg-[#0A66C2]/20 dark:text-[#66B2FF] font-medium">
+                                {field.field}: {field.value.length > 30 ? field.value.slice(0, 30) + '...' : field.value}
+                              </span>
+                            ))}
+                            {result.matchedFields.length > 4 && (
+                              <span className="text-[11px] text-meta">
+                                +{result.matchedFields.length - 4} more
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <div className="text-xs font-bold" style={{ color: 'var(--text-secondary)' }}>
+                          Score: {result.score}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              {searchResults.length > 50 && (
+                <p className="text-center text-sm text-meta">
+                  Showing 50 of {searchResults.length} results. Refine your search for more precise results.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/fuzzy-search-utils.test.ts
+++ b/apps/web/src/app/fuzzy-search-utils.test.ts
@@ -1,0 +1,163 @@
+import { fuzzySearch, getSearchableFieldLabels } from './fuzzy-search-utils';
+import { FuzzingRun } from './types';
+
+const mockRuns: FuzzingRun[] = [
+  {
+    id: 'run-001',
+    status: 'completed',
+    area: 'auth',
+    severity: 'high',
+    duration: 1500,
+    seedCount: 5000,
+    cpuInstructions: 750_000,
+    memoryBytes: 4_500_000,
+    minResourceFee: 1200,
+    crashDetail: {
+      failureCategory: 'InvariantViolation',
+      signature: 'sig:token:transfer:assert_balance_nonnegative',
+      signatureHash: 12345,
+      payload: 'balance check failed',
+      replayAction: 'replay --seed 0xabc',
+    },
+    tags: ['critical', 'production'],
+    annotations: ['Needs investigation'],
+    associatedIssues: [{ label: 'BUG-42', href: 'https://example.com/BUG-42' }],
+  },
+  {
+    id: 'run-002',
+    status: 'failed',
+    area: 'budget',
+    severity: 'critical',
+    duration: 3200,
+    seedCount: 12000,
+    cpuInstructions: 1_200_000,
+    memoryBytes: 8_000_000,
+    minResourceFee: 3500,
+    crashDetail: {
+      failureCategory: 'BudgetExceeded',
+      signature: 'sig:router:swap:budget_cpu_limit',
+      payload: 'CPU budget exceeded',
+      replayAction: 'replay --seed 0xdef',
+    },
+    tags: ['regression'],
+    associatedIssues: [],
+  },
+  {
+    id: 'run-003',
+    status: 'running',
+    area: 'state',
+    severity: 'low',
+    duration: 800,
+    seedCount: 2000,
+    cpuInstructions: 300_000,
+    memoryBytes: 2_000_000,
+    minResourceFee: 500,
+    crashDetail: null,
+    tags: [],
+    annotations: [],
+    associatedIssues: [],
+  },
+];
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function testFuzzySearchEmptyQuery() {
+  const results = fuzzySearch(mockRuns, '');
+  assert(results.length === 0, 'Empty query should return empty results');
+  console.log('  ✓ Empty query returns no results');
+}
+
+function testFuzzySearchById() {
+  const results = fuzzySearch(mockRuns, 'run-001');
+  assert(results.length >= 1, 'Should find by run ID');
+  assert(results[0].run.id === 'run-001', 'First result should be matching run');
+  assert(results[0].score > 0, 'Should have a positive score');
+  console.log('  ✓ Search by ID works');
+}
+
+function testFuzzySearchByStatus() {
+  const results = fuzzySearch(mockRuns, 'failed');
+  assert(results.length >= 1, 'Should find failed runs');
+  const found = results.some((r) => r.run.status === 'failed');
+  assert(found, 'At least one result should have status "failed"');
+  console.log('  ✓ Search by status works');
+}
+
+function testFuzzySearchByArea() {
+  const results = fuzzySearch(mockRuns, 'auth');
+  assert(results.length >= 1, 'Should find auth area runs');
+  console.log('  ✓ Search by area works');
+}
+
+function testFuzzySearchBySignature() {
+  const results = fuzzySearch(mockRuns, 'balance');
+  assert(results.length >= 1, 'Should find runs with balance in crash signature');
+  console.log('  ✓ Search by crash signature works');
+}
+
+function testFuzzySearchRanking() {
+  const results = fuzzySearch(mockRuns, 'critical');
+  assert(results.length > 0, 'Should find results for "critical"');
+  for (let i = 1; i < results.length; i++) {
+    assert(results[i - 1].score >= results[i].score, 'Results should be sorted by score descending');
+  }
+  console.log('  ✓ Results are ranked by score');
+}
+
+function testFuzzySearchMatchedFields() {
+  const results = fuzzySearch(mockRuns, 'run-001');
+  if (results.length > 0) {
+    assert(results[0].matchedFields.length > 0, 'Should report matched fields');
+    const hasIdMatch = results[0].matchedFields.some((f) => f.field === 'Run ID');
+    assert(hasIdMatch, 'Should show Run ID as matched field');
+  }
+  console.log('  ✓ Matched fields are reported');
+}
+
+function testFuzzySearchByTag() {
+  const results = fuzzySearch(mockRuns, 'production');
+  assert(results.length >= 1, 'Should find runs with "production" tag');
+  console.log('  ✓ Search by tags works');
+}
+
+function testFuzzySearchAllRuns() {
+  const results = fuzzySearch(mockRuns, 'run');
+  assert(results.length >= 1, 'Should find runs matching "run"');
+  console.log('  ✓ Broad search returns results');
+}
+
+function testGetSearchableFieldLabels() {
+  const labels = getSearchableFieldLabels();
+  assert(labels.length > 0, 'Should return field labels');
+  assert(labels.includes('Run ID'), 'Should include Run ID');
+  assert(labels.includes('Status'), 'Should include Status');
+  console.log('  ✓ Searchable field labels are returned');
+}
+
+const tests = [
+  testFuzzySearchEmptyQuery,
+  testFuzzySearchById,
+  testFuzzySearchByStatus,
+  testFuzzySearchByArea,
+  testFuzzySearchBySignature,
+  testFuzzySearchRanking,
+  testFuzzySearchMatchedFields,
+  testFuzzySearchByTag,
+  testFuzzySearchAllRuns,
+  testGetSearchableFieldLabels,
+];
+
+let passed = 0;
+let failed = 0;
+for (const test of tests) {
+  try {
+    test();
+    passed++;
+  } catch (e) {
+    console.error(`  ✗ ${test.name}: ${(e as Error).message}`);
+    failed++;
+  }
+}
+console.log(`\n${passed} passed, ${failed} failed`);

--- a/apps/web/src/app/fuzzy-search-utils.ts
+++ b/apps/web/src/app/fuzzy-search-utils.ts
@@ -1,0 +1,140 @@
+import { FuzzingRun } from './types';
+
+export interface FuzzySearchResult {
+  run: FuzzingRun;
+  score: number;
+  matchedFields: Array<{ field: string; value: string }>;
+}
+
+function normalize(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  return String(value).toLowerCase().trim();
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  if (a.length > b.length) [a, b] = [b, a];
+  const row = new Array(a.length + 1).fill(0).map((_, i) => i);
+  for (let j = 1; j <= b.length; j++) {
+    let prev = row[0];
+    row[0] = j;
+    for (let i = 1; i <= a.length; i++) {
+      const tmp = row[i];
+      row[i] = Math.min(
+        prev + (a[i - 1] === b.charAt(j - 1) ? 0 : 1),
+        row[i] + 1,
+        row[i - 1] + 1,
+      );
+      prev = tmp;
+    }
+  }
+  return row[a.length];
+}
+
+function fieldScore(haystack: string, needle: string): number {
+  if (!needle || !haystack) return 0;
+  const h = haystack.toLowerCase();
+  const n = needle.toLowerCase();
+  if (h === n) return 100;
+  if (h.startsWith(n)) return 90;
+  if (h.includes(n)) return 75;
+  const dist = levenshtein(n, h.substring(0, Math.min(h.length, n.length + 3)));
+  if (dist <= 1) return 60;
+  if (dist <= 2) return 40;
+  if (dist <= 3) return 20;
+  const words = h.split(/\s+/);
+  for (const word of words) {
+    if (word.includes(n)) return 50;
+    const wd = levenshtein(n, word);
+    if (wd <= 1) return 45;
+    if (wd <= 2) return 25;
+  }
+  return 0;
+}
+
+interface RunField {
+  key: string;
+  label: string;
+  value: string;
+}
+
+function getRunFields(run: FuzzingRun): RunField[] {
+  const fields: RunField[] = [
+    { key: 'id', label: 'Run ID', value: normalize(run.id) },
+    { key: 'status', label: 'Status', value: normalize(run.status) },
+    { key: 'area', label: 'Area', value: normalize(run.area) },
+    { key: 'severity', label: 'Severity', value: normalize(run.severity) },
+    { key: 'duration', label: 'Duration', value: normalize(run.duration) },
+    { key: 'seedCount', label: 'Seed Count', value: normalize(run.seedCount) },
+    { key: 'cpuInstructions', label: 'CPU Instructions', value: normalize(run.cpuInstructions) },
+    { key: 'memoryBytes', label: 'Memory Bytes', value: normalize(run.memoryBytes) },
+    { key: 'minResourceFee', label: 'Min Resource Fee', value: normalize(run.minResourceFee) },
+  ];
+  if (run.crashDetail) {
+    fields.push({ key: 'crashDetail.failureCategory', label: 'Failure Category', value: normalize(run.crashDetail.failureCategory) });
+    fields.push({ key: 'crashDetail.signature', label: 'Crash Signature', value: normalize(run.crashDetail.signature) });
+    if (run.crashDetail.signatureHash) fields.push({ key: 'crashDetail.signatureHash', label: 'Signature Hash', value: normalize(run.crashDetail.signatureHash) });
+    fields.push({ key: 'crashDetail.payload', label: 'Crash Payload', value: normalize(run.crashDetail.payload) });
+    fields.push({ key: 'crashDetail.replayAction', label: 'Replay Action', value: normalize(run.crashDetail.replayAction) });
+  }
+  if (run.tags) {
+    run.tags.forEach((tag, i) => {
+      fields.push({ key: `tags[${i}]`, label: 'Tag', value: normalize(tag) });
+    });
+  }
+  if (run.annotations) {
+    run.annotations.forEach((note, i) => {
+      fields.push({ key: `annotations[${i}]`, label: 'Annotation', value: normalize(note) });
+    });
+  }
+  if (run.associatedIssues) {
+    run.associatedIssues.forEach((issue, i) => {
+      fields.push({ key: `associatedIssues[${i}]`, label: 'Issue', value: normalize(issue.label) });
+    });
+  }
+  return fields;
+}
+
+export function fuzzySearch(
+  runs: FuzzingRun[],
+  query: string,
+): FuzzySearchResult[] {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  const tokens = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
+  const results: FuzzySearchResult[] = [];
+  for (const run of runs) {
+    const fields = getRunFields(run);
+    let totalScore = 0;
+    const matchedFields: Array<{ field: string; value: string }> = [];
+    for (const field of fields) {
+      let fieldMatched = false;
+      for (const token of tokens) {
+        const s = fieldScore(field.value, token);
+        if (s > 0) {
+          totalScore += s;
+          if (!fieldMatched) {
+            matchedFields.push({ field: field.label, value: field.value });
+            fieldMatched = true;
+          }
+        }
+      }
+    }
+    if (totalScore > 0) {
+      results.push({ run, score: totalScore, matchedFields });
+    }
+  }
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}
+
+export function getSearchableFieldLabels(): string[] {
+  return [
+    'Run ID', 'Status', 'Area', 'Severity', 'Duration',
+    'Seed Count', 'CPU Instructions', 'Memory Bytes', 'Min Resource Fee',
+    'Failure Category', 'Crash Signature', 'Signature Hash',
+    'Crash Payload', 'Replay Action', 'Tag', 'Annotation', 'Issue',
+  ];
+}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -1,0 +1,5 @@
+import CreateFuzzySearchPage from '../create-fuzzy-search-page';
+
+export default function SearchRoutePage() {
+  return <CreateFuzzySearchPage />;
+}


### PR DESCRIPTION
Closes #1124

## Summary
Adds a dedicated fuzzy search page that searches across all run fields with relevance-based ranking.

## Changes
- New /search route with fuzzy search UI
- fuzzy-search-utils.ts with Levenshtein-based fuzzy matching and scoring
- Score-based ranking of search results
- Matched field highlighting
- Searchable across ID, status, area, severity, crash details, tags, annotations, and more
- Debounced input for responsive UX
- Proper loading, empty, and error states
- Comprehensive test coverage

## Verification
- [x] npm run lint — 0 errors
- [x] npm run build — compiles
- [x] npm test — all pass