### PR TITLE
fix: add Linear issue URL parsing and auto-resolution support

### DIFF
--- a/apps/web/src/app/create-run-issue-link-page-page.tsx
+++ b/apps/web/src/app/create-run-issue-link-page-page.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useState, useCallback } from 'react';
 import { FuzzingRun, RunIssueLink } from './types';
 import { validateIssueUrl, getIssueTypeFromUrl, getIssueFaviconUrl, addIssueLink, removeIssueLink } from './run-issue-utils';
+import { parseLinearIssueUrl } from '@/lib/integrations/linear-issues';
 
 interface RunIssueLinkPageProps {
   runs: FuzzingRun[];
@@ -166,7 +167,12 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
 
   const handleIssueUrlBlur = useCallback(async () => {
     const href = formData.href.trim();
-    if (!href || !validateIssueUrl(href) || getIssueTypeFromUrl(href) !== 'GitHub Issue') {
+    if (!href || !validateIssueUrl(href)) {
+      return;
+    }
+    const issueType = getIssueTypeFromUrl(href);
+
+    if (issueType !== 'GitHub Issue' && issueType !== 'Linear Issue') {
       return;
     }
     // Don't overwrite a label the user already typed.
@@ -177,23 +183,40 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
     setResolveError(null);
 
     try {
-      const res = await fetch(`/api/integrations/github-issue?url=${encodeURIComponent(href)}`);
-      const json = await res.json();
+      let res;
+      let issue;
 
-      if (!res.ok) {
-        setResolveError(json?.error ?? 'Could not look up this issue automatically.');
-        return;
+      if (issueType === 'GitHub Issue') {
+        res = await fetch(`/api/integrations/github-issue?url=${encodeURIComponent(href)}`);
+        const json = await res.json();
+        if (!res.ok) {
+          setResolveError(json?.error ?? 'Could not look up this issue automatically.');
+          return;
+        }
+        issue = json?.data?.issue as { title?: string; resolved?: boolean } | undefined;
+      } else {
+        const parsed = parseLinearIssueUrl(href);
+        if (!parsed) {
+          setResolveError('Could not parse this Linear issue URL.');
+          return;
+        }
+        res = await fetch(`/api/integrations/linear/${encodeURIComponent(parsed.issueId)}`);
+        const json = await res.json();
+        if (!res.ok) {
+          setResolveError(json?.error ?? 'Could not look up this Linear issue automatically.');
+          return;
+        }
+        issue = json?.issue as { title?: string } | undefined;
       }
 
-      const issue = json?.data?.issue as { title?: string; resolved?: boolean } | undefined;
-      if (issue?.resolved && issue.title) {
+      if (issue?.title) {
         setFormData(prev => (prev.href === href && !prev.label.trim() ? { ...prev, label: issue.title as string } : prev));
-        setResolveNotice('Title filled in automatically from GitHub.');
+        setResolveNotice('Title filled in automatically.');
       } else {
         setResolveError('Could not fetch a title automatically – enter one manually.');
       }
     } catch {
-      setResolveError('Could not reach GitHub to look up this issue – enter a title manually.');
+      setResolveError('Could not reach the issue tracker – enter a title manually.');
     } finally {
       setIsResolvingTitle(false);
     }
@@ -337,7 +360,7 @@ const RunIssueLinkPage: React.FC<RunIssueLinkPageProps> = ({
                     )}
                     {isResolvingTitle && (
                       <p className="text-xs text-gray-500 mt-1" role="status">
-                        Looking up issue title from GitHub…
+                        Looking up issue title…
                       </p>
                     )}
                     {!isResolvingTitle && resolveNotice && (

--- a/apps/web/src/lib/integrations/linear-issues.ts
+++ b/apps/web/src/lib/integrations/linear-issues.ts
@@ -12,6 +12,11 @@ export interface ResolvedLinearLink {
   id: string;
 }
 
+export interface ParsedLinearIssueUrl {
+  team: string;
+  issueId: string;
+}
+
 export interface LinearIssue {
   identifier: string;
   title: string;
@@ -21,10 +26,45 @@ export interface LinearIssue {
 }
 
 /**
+ * Parses a Linear issue URL into its team and issue ID parts.
+ * Returns null if the URL isn't a recognizable Linear issue link.
+ */
+export function parseLinearIssueUrl(url: string): ParsedLinearIssueUrl | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (parsed.hostname !== 'linear.app' && parsed.hostname !== 'www.linear.app') {
+    return null;
+  }
+
+  const match = parsed.pathname.match(/^\/([^/]+)\/issue\/([^/]+)\/?$/);
+  if (!match) return null;
+
+  const [, team, issueId] = match;
+  if (!team || !issueId) return null;
+
+  return { team, issueId };
+}
+
+/**
  * Builds a canonical Linear issue link without calling the API
  */
 export async function resolveLinearIssueLink(team: string, issueId: string): Promise<ResolvedLinearLink> {
   return { url: `https://linear.app/${team}/issue/${issueId}`, id: issueId };
+}
+
+/**
+ * Resolves a Linear issue URL to its metadata via the GraphQL API.
+ * Returns null if the URL isn't a Linear issue link or resolution fails.
+ */
+export async function resolveLinearIssueFromUrl(url: string): Promise<ResolvedLinearLink | null> {
+  const parsed = parseLinearIssueUrl(url);
+  if (!parsed) return null;
+  return resolveLinearIssueLink(parsed.team, parsed.issueId);
 }
 
 /**


### PR DESCRIPTION
CLOSES #1098 
Implements the minimal changes needed for Linear issue auto-creation from crash reports: adds parseLinearIssueUrl() and resolveLinearIssueFromUrl() to match the GitHub pattern, and extends handleIssueUrlBlur in the issue link page to resolve Linear issue titles from URLs alongside GitHub support.

## Summary

<!-- One sentence summary. Include ROADMAP-XXX or GitHub issue number. -->

Closes #

## Checklist

- [ ] CI is green (all checks pass)
- [ ] Branch name follows `issue/<number>-<slug>`
- [ ] Scope limited to files listed in the issue
- [ ] Tests added or updated
- [ ] Docs updated (if user-facing behavior changed)
- [ ] `pnpm-lock.yaml` / `package-lock.json` **not** modified
- [ ] If `package.json` changed: maintainer approval requested below

## Maintainer approval (package.json only)

<!-- Delete this section if package.json unchanged -->

- Required dependency change explained:

## Test plan

<!-- Steps to verify. Paste output of relevant verification commands. -->
