### PR TITLE
[ui] Add loading skeleton for all data-fetching pages (not just text)

### DIFF
--- a/apps/web/src/app/analytics/calendar/loading.tsx
+++ b/apps/web/src/app/analytics/calendar/loading.tsx
@@ -1,0 +1,5 @@
+import { CalendarSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <CalendarSkeleton />;
+}

--- a/apps/web/src/app/analytics/clusters/loading.tsx
+++ b/apps/web/src/app/analytics/clusters/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="cards" />;
+}

--- a/apps/web/src/app/analytics/comparison/loading.tsx
+++ b/apps/web/src/app/analytics/comparison/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="cards" />;
+}

--- a/apps/web/src/app/analytics/flaky/loading.tsx
+++ b/apps/web/src/app/analytics/flaky/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/analytics/heatmap/loading.tsx
+++ b/apps/web/src/app/analytics/heatmap/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="cards" />;
+}

--- a/apps/web/src/app/analytics/loading.tsx
+++ b/apps/web/src/app/analytics/loading.tsx
@@ -1,0 +1,5 @@
+import { AnalyticsCardsSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <AnalyticsCardsSkeleton />;
+}

--- a/apps/web/src/app/analytics/taxonomy/loading.tsx
+++ b/apps/web/src/app/analytics/taxonomy/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/campaign-comparison/loading.tsx
+++ b/apps/web/src/app/campaign-comparison/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="cards" />;
+}

--- a/apps/web/src/app/campaign-milestone-timeline/loading.tsx
+++ b/apps/web/src/app/campaign-milestone-timeline/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="list" />;
+}

--- a/apps/web/src/app/filter-presets/loading.tsx
+++ b/apps/web/src/app/filter-presets/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="list" />;
+}

--- a/apps/web/src/app/flaky-tests/loading.tsx
+++ b/apps/web/src/app/flaky-tests/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/heatmap-calendar/loading.tsx
+++ b/apps/web/src/app/heatmap-calendar/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="cards" />;
+}

--- a/apps/web/src/app/integrations/api-errors/loading.tsx
+++ b/apps/web/src/app/integrations/api-errors/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/integrations/artifacts/loading.tsx
+++ b/apps/web/src/app/integrations/artifacts/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/integrations/auth/loading.tsx
+++ b/apps/web/src/app/integrations/auth/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/integrations/ci-replay/loading.tsx
+++ b/apps/web/src/app/integrations/ci-replay/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/integrations/db-migrations/loading.tsx
+++ b/apps/web/src/app/integrations/db-migrations/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/integrations/github-actions/loading.tsx
+++ b/apps/web/src/app/integrations/github-actions/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/integrations/grafana/loading.tsx
+++ b/apps/web/src/app/integrations/grafana/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/integrations/issue-links/loading.tsx
+++ b/apps/web/src/app/integrations/issue-links/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="list" />;
+}

--- a/apps/web/src/app/integrations/loading.tsx
+++ b/apps/web/src/app/integrations/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="cards" />;
+}

--- a/apps/web/src/app/integrations/pagerduty/loading.tsx
+++ b/apps/web/src/app/integrations/pagerduty/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/integrations/prometheus/loading.tsx
+++ b/apps/web/src/app/integrations/prometheus/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/integrations/replay-e2e/loading.tsx
+++ b/apps/web/src/app/integrations/replay-e2e/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/integrations/sanity-check/loading.tsx
+++ b/apps/web/src/app/integrations/sanity-check/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/integrations/sentry/loading.tsx
+++ b/apps/web/src/app/integrations/sentry/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/integrations/ui-harness/loading.tsx
+++ b/apps/web/src/app/integrations/ui-harness/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="cards" />;
+}

--- a/apps/web/src/app/integrations/webhooks/loading.tsx
+++ b/apps/web/src/app/integrations/webhooks/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/logs/loading.tsx
+++ b/apps/web/src/app/logs/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/maintainer/loading.tsx
+++ b/apps/web/src/app/maintainer/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="cards" />;
+}

--- a/apps/web/src/app/notification-center/loading.tsx
+++ b/apps/web/src/app/notification-center/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="list" />;
+}

--- a/apps/web/src/app/onboarding-wizard/loading.tsx
+++ b/apps/web/src/app/onboarding-wizard/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/onboarding/loading.tsx
+++ b/apps/web/src/app/onboarding/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/query-builder/loading.tsx
+++ b/apps/web/src/app/query-builder/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/regression-suite/loading.tsx
+++ b/apps/web/src/app/regression-suite/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/app/reproduction-snippet/loading.tsx
+++ b/apps/web/src/app/reproduction-snippet/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/runs/[id]/replay-history/loading.tsx
+++ b/apps/web/src/app/runs/[id]/replay-history/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="list" />;
+}

--- a/apps/web/src/app/runs/loading.tsx
+++ b/apps/web/src/app/runs/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/apps/web/src/app/runs/query/loading.tsx
+++ b/apps/web/src/app/runs/query/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/search/loading.tsx
+++ b/apps/web/src/app/search/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="list" />;
+}

--- a/apps/web/src/app/settings/accessibility/loading.tsx
+++ b/apps/web/src/app/settings/accessibility/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/settings/alerting/loading.tsx
+++ b/apps/web/src/app/settings/alerting/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/settings/alerting/presets/loading.tsx
+++ b/apps/web/src/app/settings/alerting/presets/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="list" />;
+}

--- a/apps/web/src/app/settings/api/loading.tsx
+++ b/apps/web/src/app/settings/api/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/settings/loading.tsx
+++ b/apps/web/src/app/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="list" />;
+}

--- a/apps/web/src/app/settings/network/loading.tsx
+++ b/apps/web/src/app/settings/network/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/settings/notifications/loading.tsx
+++ b/apps/web/src/app/settings/notifications/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/settings/reporting/loading.tsx
+++ b/apps/web/src/app/settings/reporting/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="form" />;
+}

--- a/apps/web/src/app/trends/loading.tsx
+++ b/apps/web/src/app/trends/loading.tsx
@@ -1,0 +1,5 @@
+import { TrendsChartSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <TrendsChartSkeleton />;
+}

--- a/apps/web/src/app/triage/board/loading.tsx
+++ b/apps/web/src/app/triage/board/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="cards" />;
+}

--- a/apps/web/src/app/triage/loading.tsx
+++ b/apps/web/src/app/triage/loading.tsx
@@ -1,0 +1,5 @@
+import { GenericPageSkeleton } from "@/components/LoadingSkeleton";
+
+export default function Loading() {
+  return <GenericPageSkeleton variant="table" />;
+}

--- a/apps/web/src/components/LoadingSkeleton.tsx
+++ b/apps/web/src/components/LoadingSkeleton.tsx
@@ -140,3 +140,78 @@ export function CalendarSkeleton({ weeks = 20 }: { weeks?: number }) {
     </div>
   );
 }
+
+export function GenericPageSkeleton({
+  variant = "cards",
+  rows = 6,
+}: {
+  variant?: "cards" | "table" | "list" | "form";
+  rows?: number;
+}) {
+  return (
+    <div role="status" aria-live="polite" aria-label="Loading page content" className="space-y-6">
+      {/* Page header skeleton */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="skeleton h-7 w-48" />
+        <div className="skeleton h-9 w-28" />
+      </div>
+
+      {variant === "cards" && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
+          {Array.from({ length: rows }).map((_, i) => (
+            <div key={i} className="card card-padding">
+              <div className="skeleton h-4 w-2/3 mb-3" />
+              <div className="skeleton h-3 w-full mb-2" />
+              <div className="skeleton h-3 w-4/5" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {variant === "table" && (
+        <div className="card table-responsive">
+          <table className="data-table">
+            <thead>
+              <tr>
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <th key={i}><div className="skeleton h-4 w-16" /></th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: rows }).map((_, i) => (
+                <tr key={i}>
+                  {Array.from({ length: 4 }).map((_, j) => (
+                    <td key={j}><div className="skeleton h-4 w-20" /></td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {variant === "list" && (
+        <div className="card divide-y divide-zinc-100 dark:divide-zinc-900">
+          {Array.from({ length: rows }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between p-4">
+              <div className="skeleton h-4 w-1/3" />
+              <div className="skeleton h-6 w-16 rounded-full" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {variant === "form" && (
+        <div className="card card-padding space-y-4">
+          {Array.from({ length: rows }).map((_, i) => (
+            <div key={i}>
+              <div className="skeleton h-3 w-24 mb-2" />
+              <div className="skeleton h-9 w-full" />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1208

## Summary
Audited every real route (`page.tsx`) under `apps/web/src/app` and found only the homepage had a route-level `loading.tsx` — every other data-fetching page had no skeleton. Several bespoke skeleton components already existed in `components/LoadingSkeleton.tsx` (`CalendarSkeleton`, `TrendsChartSkeleton`, `AnalyticsCardsSkeleton`, `DashboardSkeleton`) but were never wired into a `loading.tsx` for their matching routes.

## Changes
- Added `GenericPageSkeleton` (variants: `cards` | `table` | `list` | `form`) to `components/LoadingSkeleton.tsx`, reusing the existing `.skeleton` shimmer class and `--skeleton-from`/`--skeleton-to` CSS variables — automatically light/dark-aware and respects `prefers-reduced-motion` (already handled globally in `globals.css`).
- Wired the pre-existing bespoke skeletons into `loading.tsx` for their matching routes (`analytics/calendar`, `trends`, `analytics`, `runs`).
- Added `loading.tsx` (using `GenericPageSkeleton` with a content-appropriate variant) to every other previously-missing data-fetching route — analytics subpages, all integrations pages, all settings pages, runs detail/query, triage, search, logs, and the remaining feature pages.

## Acceptance criteria
- [x] Loading skeleton implemented for all data-fetching pages, not just plain text.
- [x] Light/dark mode — uses existing theme-aware CSS variables.
- [x] Responsive on mobile/desktop — reuses existing responsive grid/table classes.
- [x] Follows the existing design system (`.skeleton`, `.card`, `.card-padding`).

## Verification
- `npm run lint` — 0 errors
- `npm run build` — compiles successfully
- `npm test` — all existing tests pass