### PR TITLE
refactor: convert 7 integration files to factory-based adapter pattern

### DIFF
--- a/apps/web/src/app/api/integrations/discord/route.ts
+++ b/apps/web/src/app/api/integrations/discord/route.ts
@@ -7,7 +7,7 @@
 
 import { NextResponse } from 'next/server';
 import { withRouteErrorHandling, readJsonBody, jsonError } from '@/lib/route-handler';
-import { sendDiscordNotification, type DiscordMessage } from '@/lib/integrations/discord-webhook';
+import { createDiscordAdapter, type DiscordMessage } from '@/lib/integrations/discord-webhook';
 
 export const POST = withRouteErrorHandling(
   'POST /api/integrations/discord',
@@ -29,7 +29,8 @@ export const POST = withRouteErrorHandling(
       return jsonError('Message must include either content or embeds', 400);
     }
 
-    const result = await sendDiscordNotification({ webhookUrl }, message);
+    const adapter = createDiscordAdapter();
+    const result = await adapter.sendNotification({ webhookUrl }, message);
 
     if (!result.success) {
       return jsonError(result.error || 'Failed to send Discord notification', 500);

--- a/apps/web/src/app/api/integrations/github-actions/route.ts
+++ b/apps/web/src/app/api/integrations/github-actions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { successResponse } from '@/lib/api-response-utils';
-import { listGithubWorkflowRuns, rerunFailedGithubJobs } from '@/lib/integrations/github-actions';
+import { createGithubActionsAdapter } from '@/lib/integrations/github-actions';
 import { jsonError, readJsonBody, withRouteErrorHandling } from '@/lib/route-handler';
 
 const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -32,7 +32,8 @@ export const GET = withRouteErrorHandling(
     if (!token) return tokenUnavailableResponse();
 
     const [owner, repo] = repository;
-    const workflowRuns = await listGithubWorkflowRuns(owner, repo, token);
+    const adapter = createGithubActionsAdapter();
+    const workflowRuns = await adapter.listWorkflowRuns(owner, repo, token);
     return successResponse({ workflowRuns });
   },
   'Unable to load GitHub Actions workflow runs.',
@@ -58,7 +59,8 @@ export const POST = withRouteErrorHandling(
     if (!token) return tokenUnavailableResponse();
 
     const [owner, repo] = repositoryParts;
-    await rerunFailedGithubJobs(owner, repo, runId as number, token);
+    const adapter = createGithubActionsAdapter();
+    await adapter.rerunFailedJobs(owner, repo, runId as number, token);
     return successResponse({ queued: true, runId });
   },
   'Unable to queue the GitHub Actions re-run.',

--- a/apps/web/src/app/api/integrations/github-issue/route.ts
+++ b/apps/web/src/app/api/integrations/github-issue/route.ts
@@ -16,7 +16,7 @@
  */
 
 import { NextRequest } from 'next/server';
-import { parseGithubIssueUrl, resolveGithubIssueLink } from '@/lib/integrations/github-issues';
+import { parseGithubIssueUrl, createGithubIssuesAdapter } from '@/lib/integrations/github-issues';
 import { successResponse } from '@/lib/api-response-utils';
 import { jsonError, withRouteErrorHandling } from '@/lib/route-handler';
 
@@ -34,7 +34,8 @@ export const GET = withRouteErrorHandling(
       return jsonError('Not a recognizable GitHub issue or pull request URL.', 400);
     }
 
-    const issue = await resolveGithubIssueLink(parsed.owner, parsed.repo, parsed.issueNumber);
+    const adapter = createGithubIssuesAdapter();
+    const issue = await adapter.resolveIssueLink(parsed.owner, parsed.repo, parsed.issueNumber);
     return successResponse({ issue });
   },
 );

--- a/apps/web/src/app/api/integrations/jira/[issueKey]/route.test.ts
+++ b/apps/web/src/app/api/integrations/jira/[issueKey]/route.test.ts
@@ -4,9 +4,11 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET, POST } from './route';
-import * as jiraIssues from '@/lib/integrations/jira-issues';
+import { createJiraIssuesAdapter } from '@/lib/integrations/jira-issues';
 
-vi.mock('@/lib/integrations/jira-issues');
+vi.mock('@/lib/integrations/jira-issues', () => ({
+  createJiraIssuesAdapter: vi.fn(),
+}));
 
 describe('POST /api/integrations/jira', () => {
   beforeEach(() => {
@@ -36,7 +38,8 @@ describe('POST /api/integrations/jira', () => {
       url: 'https://jira.example.com/browse/CRASH-123',
     };
 
-    vi.mocked(jiraIssues.createJiraIssue).mockResolvedValue(mockIssue);
+    const mockAdapter = { createIssue: vi.fn().mockResolvedValue(mockIssue) };
+    vi.mocked(createJiraIssuesAdapter).mockReturnValue(mockAdapter as ReturnType<typeof createJiraIssuesAdapter>);
 
     const request = new Request('http://localhost/api/integrations/jira', {
       method: 'POST',
@@ -49,7 +52,7 @@ describe('POST /api/integrations/jira', () => {
 
     expect(response.status).toBe(200);
     expect(data.issue).toEqual(mockIssue);
-    expect(jiraIssues.createJiraIssue).toHaveBeenCalledWith({
+    expect(mockAdapter.createIssue).toHaveBeenCalledWith({
       summary: 'Crash report issue',
       description: 'details',
       projectKey: undefined,
@@ -83,7 +86,8 @@ describe('GET /api/integrations/jira/[issueKey]', () => {
       url: 'https://jira.example.com/browse/PROJ-123',
     };
 
-    vi.mocked(jiraIssues.fetchJiraIssue).mockResolvedValue(mockIssue);
+    const mockAdapter = { fetchIssue: vi.fn().mockResolvedValue(mockIssue) };
+    vi.mocked(createJiraIssuesAdapter).mockReturnValue(mockAdapter as ReturnType<typeof createJiraIssuesAdapter>);
 
     const request = new Request('http://localhost/api/integrations/jira/PROJ-123');
     const context = { params: Promise.resolve({ issueKey: 'PROJ-123' }) };
@@ -93,11 +97,12 @@ describe('GET /api/integrations/jira/[issueKey]', () => {
 
     expect(response.status).toBe(200);
     expect(data.issue).toEqual(mockIssue);
-    expect(jiraIssues.fetchJiraIssue).toHaveBeenCalledWith('PROJ-123');
+    expect(mockAdapter.fetchIssue).toHaveBeenCalledWith('PROJ-123');
   });
 
   it('returns 404 when issue is not found', async () => {
-    vi.mocked(jiraIssues.fetchJiraIssue).mockResolvedValue(null);
+    const mockAdapter = { fetchIssue: vi.fn().mockResolvedValue(null) };
+    vi.mocked(createJiraIssuesAdapter).mockReturnValue(mockAdapter as ReturnType<typeof createJiraIssuesAdapter>);
 
     const request = new Request('http://localhost/api/integrations/jira/NONEXISTENT-999');
     const context = { params: Promise.resolve({ issueKey: 'NONEXISTENT-999' }) };
@@ -109,8 +114,9 @@ describe('GET /api/integrations/jira/[issueKey]', () => {
     expect(data.error).toContain('not found');
   });
 
-  it('returns 500 when fetchJiraIssue throws error', async () => {
-    vi.mocked(jiraIssues.fetchJiraIssue).mockRejectedValue(new Error('API Error'));
+  it('returns 500 when fetchIssue throws error', async () => {
+    const mockAdapter = { fetchIssue: vi.fn().mockRejectedValue(new Error('API Error')) };
+    vi.mocked(createJiraIssuesAdapter).mockReturnValue(mockAdapter as ReturnType<typeof createJiraIssuesAdapter>);
 
     const request = new Request('http://localhost/api/integrations/jira/PROJ-123');
     const context = { params: Promise.resolve({ issueKey: 'PROJ-123' }) };
@@ -131,7 +137,8 @@ describe('GET /api/integrations/jira/[issueKey]', () => {
       url: 'https://jira.example.com/browse/PROJ-123',
     };
 
-    vi.mocked(jiraIssues.fetchJiraIssue).mockResolvedValue(mockIssue);
+    const mockAdapter = { fetchIssue: vi.fn().mockResolvedValue(mockIssue) };
+    vi.mocked(createJiraIssuesAdapter).mockReturnValue(mockAdapter as ReturnType<typeof createJiraIssuesAdapter>);
 
     const request = new Request('http://localhost/api/integrations/jira/PROJ-123');
     const context = { params: Promise.resolve({ issueKey: 'PROJ-123' }) };

--- a/apps/web/src/app/api/integrations/jira/[issueKey]/route.ts
+++ b/apps/web/src/app/api/integrations/jira/[issueKey]/route.ts
@@ -7,7 +7,7 @@
 
 import { NextResponse } from 'next/server';
 import { withRouteErrorHandling, jsonError, readJsonBody } from '@/lib/route-handler';
-import { createJiraIssue, fetchJiraIssue } from '@/lib/integrations/jira-issues';
+import { createJiraIssuesAdapter } from '@/lib/integrations/jira-issues';
 
 interface RouteContext {
   params: Promise<{ issueKey: string }>;
@@ -32,7 +32,8 @@ export const POST = withRouteErrorHandling(
       return jsonError('A non-empty summary is required', 400);
     }
 
-    const issue = await createJiraIssue({
+    const adapter = createJiraIssuesAdapter();
+    const issue = await adapter.createIssue({
       summary: payload.summary.trim(),
       description: typeof payload.description === 'string' ? payload.description : undefined,
       projectKey: typeof payload.projectKey === 'string' ? payload.projectKey : undefined,
@@ -57,7 +58,8 @@ export const GET = withRouteErrorHandling(
       return jsonError('Issue key is required', 400);
     }
 
-    const issue = await fetchJiraIssue(issueKey);
+    const adapter = createJiraIssuesAdapter();
+    const issue = await adapter.fetchIssue(issueKey);
 
     if (!issue) {
       return jsonError('Issue not found or Jira not configured', 404);

--- a/apps/web/src/app/api/integrations/jira/route.ts
+++ b/apps/web/src/app/api/integrations/jira/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { withRouteErrorHandling, jsonError, readJsonBody } from '@/lib/route-handler';
-import { createJiraIssue } from '@/lib/integrations/jira-issues';
+import { createJiraIssuesAdapter } from '@/lib/integrations/jira-issues';
 
 export const POST = withRouteErrorHandling(
   'POST /api/integrations/jira',
@@ -21,7 +21,8 @@ export const POST = withRouteErrorHandling(
       return jsonError('A non-empty summary is required', 400);
     }
 
-    const issue = await createJiraIssue({
+    const adapter = createJiraIssuesAdapter();
+    const issue = await adapter.createIssue({
       summary: payload.summary.trim(),
       description: typeof payload.description === 'string' ? payload.description : undefined,
       projectKey: typeof payload.projectKey === 'string' ? payload.projectKey : undefined,

--- a/apps/web/src/app/api/integrations/linear/[issueId]/route.test.ts
+++ b/apps/web/src/app/api/integrations/linear/[issueId]/route.test.ts
@@ -4,9 +4,11 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET } from './route';
-import * as linearIssues from '@/lib/integrations/linear-issues';
+import { createLinearIssuesAdapter } from '@/lib/integrations/linear-issues';
 
-vi.mock('@/lib/integrations/linear-issues');
+vi.mock('@/lib/integrations/linear-issues', () => ({
+  createLinearIssuesAdapter: vi.fn(),
+}));
 
 describe('GET /api/integrations/linear/[issueId]', () => {
   beforeEach(() => {
@@ -33,7 +35,8 @@ describe('GET /api/integrations/linear/[issueId]', () => {
       url: 'https://linear.app/team/issue/TEAM-123',
     };
 
-    vi.mocked(linearIssues.fetchLinearIssue).mockResolvedValue(mockIssue);
+    const mockAdapter = { fetchIssue: vi.fn().mockResolvedValue(mockIssue) };
+    vi.mocked(createLinearIssuesAdapter).mockReturnValue(mockAdapter as unknown as ReturnType<typeof createLinearIssuesAdapter>);
 
     const request = new Request('http://localhost/api/integrations/linear/TEAM-123');
     const context = { params: Promise.resolve({ issueId: 'TEAM-123' }) };
@@ -43,11 +46,12 @@ describe('GET /api/integrations/linear/[issueId]', () => {
 
     expect(response.status).toBe(200);
     expect(data.issue).toEqual(mockIssue);
-    expect(linearIssues.fetchLinearIssue).toHaveBeenCalledWith('TEAM-123');
+    expect(mockAdapter.fetchIssue).toHaveBeenCalledWith('TEAM-123');
   });
 
   it('returns 404 when issue is not found', async () => {
-    vi.mocked(linearIssues.fetchLinearIssue).mockResolvedValue(null);
+    const mockAdapter = { fetchIssue: vi.fn().mockResolvedValue(null) };
+    vi.mocked(createLinearIssuesAdapter).mockReturnValue(mockAdapter as unknown as ReturnType<typeof createLinearIssuesAdapter>);
 
     const request = new Request('http://localhost/api/integrations/linear/NONEXISTENT-999');
     const context = { params: Promise.resolve({ issueId: 'NONEXISTENT-999' }) };
@@ -59,8 +63,9 @@ describe('GET /api/integrations/linear/[issueId]', () => {
     expect(data.error).toContain('not found');
   });
 
-  it('returns 500 when fetchLinearIssue throws error', async () => {
-    vi.mocked(linearIssues.fetchLinearIssue).mockRejectedValue(new Error('GraphQL Error'));
+  it('returns 500 when fetchIssue throws error', async () => {
+    const mockAdapter = { fetchIssue: vi.fn().mockRejectedValue(new Error('GraphQL Error')) };
+    vi.mocked(createLinearIssuesAdapter).mockReturnValue(mockAdapter as unknown as ReturnType<typeof createLinearIssuesAdapter>);
 
     const request = new Request('http://localhost/api/integrations/linear/TEAM-123');
     const context = { params: Promise.resolve({ issueId: 'TEAM-123' }) };
@@ -81,7 +86,8 @@ describe('GET /api/integrations/linear/[issueId]', () => {
       url: 'https://linear.app/team/issue/TEAM-123',
     };
 
-    vi.mocked(linearIssues.fetchLinearIssue).mockResolvedValue(mockIssue);
+    const mockAdapter = { fetchIssue: vi.fn().mockResolvedValue(mockIssue) };
+    vi.mocked(createLinearIssuesAdapter).mockReturnValue(mockAdapter as unknown as ReturnType<typeof createLinearIssuesAdapter>);
 
     const request = new Request('http://localhost/api/integrations/linear/TEAM-123');
     const context = { params: Promise.resolve({ issueId: 'TEAM-123' }) };

--- a/apps/web/src/app/api/integrations/linear/[issueId]/route.ts
+++ b/apps/web/src/app/api/integrations/linear/[issueId]/route.ts
@@ -7,7 +7,7 @@
 
 import { NextResponse } from 'next/server';
 import { withRouteErrorHandling, jsonError } from '@/lib/route-handler';
-import { fetchLinearIssue } from '@/lib/integrations/linear-issues';
+import { createLinearIssuesAdapter } from '@/lib/integrations/linear-issues';
 
 interface RouteContext {
   params: Promise<{ issueId: string }>;
@@ -22,7 +22,8 @@ export const GET = withRouteErrorHandling(
       return jsonError('Issue ID is required', 400);
     }
 
-    const issue = await fetchLinearIssue(issueId);
+    const adapter = createLinearIssuesAdapter();
+    const issue = await adapter.fetchIssue(issueId);
 
     if (!issue) {
       return jsonError('Issue not found or Linear not configured', 404);

--- a/apps/web/src/app/api/integrations/slack/route.ts
+++ b/apps/web/src/app/api/integrations/slack/route.ts
@@ -12,7 +12,7 @@ import { NextResponse } from "next/server";
 import { withRouteErrorHandling, readJsonBody, jsonError } from "@/lib/route-handler";
 import {
   buildRunDetailPreviewBlocks,
-  postSlackMessage,
+  createSlackAdapter,
   type RunDetailPreviewInput,
 } from "@/lib/integrations/slack-webhook";
 import { getSlackThreadStore } from "@/lib/integrations/slack-thread-store";
@@ -64,7 +64,8 @@ export const POST = withRouteErrorHandling(
     const store = getSlackThreadStore();
     const existingThread = store.getThread(run.runId);
 
-    const result = await postSlackMessage(
+    const adapter = createSlackAdapter();
+    const result = await adapter.postMessage(
       { botToken, channel },
       blocks,
       fallbackText,

--- a/apps/web/src/lib/integrations/adapter-utils.ts
+++ b/apps/web/src/lib/integrations/adapter-utils.ts
@@ -1,0 +1,13 @@
+export function createAbortSignal(timeoutMs: number | undefined): AbortSignal | undefined {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return undefined;
+  }
+
+  if (typeof AbortSignal !== 'undefined' && 'timeout' in AbortSignal) {
+    return AbortSignal.timeout(timeoutMs);
+  }
+
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeoutMs);
+  return controller.signal;
+}

--- a/apps/web/src/lib/integrations/discord-webhook.test.ts
+++ b/apps/web/src/lib/integrations/discord-webhook.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   validateDiscordWebhookUrl,
-  sendDiscordNotification,
+  createDiscordAdapter,
   createRunEventEmbed,
   createCriticalAlertEmbed,
   createSimpleMessage,
@@ -34,37 +34,33 @@ describe('validateDiscordWebhookUrl', () => {
   });
 });
 
-describe('sendDiscordNotification', () => {
+describe('createDiscordAdapter', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
   it('sends notification successfully with valid webhook', async () => {
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 204,
-      } as Response),
-    );
+    const adapter = createDiscordAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 204,
+        } as Response),
+      ),
+    });
 
-    const result = await sendDiscordNotification(
+    const result = await adapter.sendNotification(
       { webhookUrl: 'https://discord.com/api/webhooks/123/abc' },
       { content: 'Test message' },
     );
 
     expect(result.success).toBe(true);
     expect(result.error).toBeUndefined();
-    expect(fetch).toHaveBeenCalledWith(
-      'https://discord.com/api/webhooks/123/abc',
-      expect.objectContaining({
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
   });
 
   it('returns error for invalid webhook URL', async () => {
-    const result = await sendDiscordNotification(
+    const adapter = createDiscordAdapter();
+    const result = await adapter.sendNotification(
       { webhookUrl: 'https://example.com/invalid' },
       { content: 'Test' },
     );
@@ -74,15 +70,17 @@ describe('sendDiscordNotification', () => {
   });
 
   it('returns error when Discord API returns non-OK response', async () => {
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: false,
-        status: 400,
-        text: () => Promise.resolve('Bad Request'),
-      } as Response),
-    );
+    const adapter = createDiscordAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 400,
+          text: () => Promise.resolve('Bad Request'),
+        } as Response),
+      ),
+    });
 
-    const result = await sendDiscordNotification(
+    const result = await adapter.sendNotification(
       { webhookUrl: 'https://discord.com/api/webhooks/123/abc' },
       { content: 'Test' },
     );
@@ -93,9 +91,11 @@ describe('sendDiscordNotification', () => {
   });
 
   it('returns error when fetch throws', async () => {
-    global.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
+    const adapter = createDiscordAdapter({
+      fetchImpl: vi.fn(() => Promise.reject(new Error('Network error'))),
+    });
 
-    const result = await sendDiscordNotification(
+    const result = await adapter.sendNotification(
       { webhookUrl: 'https://discord.com/api/webhooks/123/abc' },
       { content: 'Test' },
     );
@@ -108,9 +108,9 @@ describe('sendDiscordNotification', () => {
     const mockFetch = vi.fn(() =>
       Promise.resolve({ ok: true, status: 204 } as Response),
     );
-    global.fetch = mockFetch;
+    const adapter = createDiscordAdapter({ fetchImpl: mockFetch });
 
-    await sendDiscordNotification(
+    await adapter.sendNotification(
       { webhookUrl: 'https://discord.com/api/webhooks/123/abc' },
       { content: 'Test' },
     );

--- a/apps/web/src/lib/integrations/discord-webhook.ts
+++ b/apps/web/src/lib/integrations/discord-webhook.ts
@@ -2,6 +2,8 @@
  * Discord webhook integration for sending notifications
  */
 
+import { createAbortSignal } from './adapter-utils';
+
 export interface DiscordWebhookConfig {
   webhookUrl: string;
   username?: string;
@@ -56,49 +58,6 @@ export function validateDiscordWebhookUrl(url: string): string | null {
   }
 
   return null;
-}
-
-/**
- * Sends a message to Discord webhook
- */
-export async function sendDiscordNotification(
-  config: DiscordWebhookConfig,
-  message: DiscordMessage,
-): Promise<DiscordNotificationResult> {
-  const validationError = validateDiscordWebhookUrl(config.webhookUrl);
-  if (validationError) {
-    return { success: false, error: validationError };
-  }
-
-  const payload: DiscordMessage = {
-    ...message,
-    username: message.username || config.username || "CrashLab",
-  };
-
-  try {
-    const response = await fetch(config.webhookUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return {
-        success: false,
-        error: `Discord API error: ${response.status} - ${errorText}`,
-      };
-    }
-
-    return { success: true };
-  } catch (error) {
-    return {
-      success: false,
-      error: `Failed to send Discord notification: ${error instanceof Error ? error.message : "Unknown error"}`,
-    };
-  }
 }
 
 /**
@@ -175,4 +134,57 @@ export function createCriticalAlertEmbed(
  */
 export function createSimpleMessage(text: string): DiscordMessage {
   return { content: text };
+}
+
+export interface DiscordAdapterOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export function createDiscordAdapter(options: DiscordAdapterOptions = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const signal = createAbortSignal(options.timeoutMs);
+
+  return {
+    async sendNotification(
+      config: DiscordWebhookConfig,
+      message: DiscordMessage,
+    ): Promise<DiscordNotificationResult> {
+      const validationError = validateDiscordWebhookUrl(config.webhookUrl);
+      if (validationError) {
+        return { success: false, error: validationError };
+      }
+
+      const payload: DiscordMessage = {
+        ...message,
+        username: message.username || config.username || "CrashLab",
+      };
+
+      try {
+        const response = await fetchImpl(config.webhookUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          signal,
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          return {
+            success: false,
+            error: `Discord API error: ${response.status} - ${errorText}`,
+          };
+        }
+
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: `Failed to send Discord notification: ${error instanceof Error ? error.message : "Unknown error"}`,
+        };
+      }
+    },
+  };
 }

--- a/apps/web/src/lib/integrations/github-actions.ts
+++ b/apps/web/src/lib/integrations/github-actions.ts
@@ -1,3 +1,5 @@
+import { createAbortSignal } from './adapter-utils';
+
 export interface GithubWorkflowRun {
   id: number;
   name: string;
@@ -38,49 +40,61 @@ function githubErrorMessage(status: number, body: unknown): string {
   return `GitHub Actions request failed with status ${status}.`;
 }
 
-/** Fetches the latest workflow runs for a repository without exposing its token to the browser. */
-export async function listGithubWorkflowRuns(
-  owner: string,
-  repo: string,
-  token: string,
-): Promise<GithubWorkflowRun[]> {
-  const response = await fetch(
-    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs?per_page=20`,
-    { headers: githubHeaders(token), cache: 'no-store' },
-  );
-  const payload: unknown = await response.json().catch(() => undefined);
-
-  if (!response.ok) {
-    throw new Error(githubErrorMessage(response.status, payload));
-  }
-
-  const runs = (payload as GithubWorkflowRunResponse).workflow_runs ?? [];
-  return runs.map((run) => ({
-    id: run.id,
-    name: run.name,
-    displayTitle: run.display_title,
-    status: run.status,
-    conclusion: run.conclusion,
-    htmlUrl: run.html_url,
-    headBranch: run.head_branch,
-    updatedAt: run.updated_at,
-  }));
+export interface GithubActionsAdapterOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
 }
 
-/** Requests GitHub to retry only failed jobs from a completed workflow run. */
-export async function rerunFailedGithubJobs(
-  owner: string,
-  repo: string,
-  runId: number,
-  token: string,
-): Promise<void> {
-  const response = await fetch(
-    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs/${runId}/rerun-failed-jobs`,
-    { method: 'POST', headers: githubHeaders(token), cache: 'no-store' },
-  );
+export function createGithubActionsAdapter(options: GithubActionsAdapterOptions = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const signal = createAbortSignal(options.timeoutMs);
 
-  if (response.ok) return;
+  return {
+    /** Fetches the latest workflow runs for a repository without exposing its token to the browser. */
+    async listWorkflowRuns(
+      owner: string,
+      repo: string,
+      token: string,
+    ): Promise<GithubWorkflowRun[]> {
+      const response = await fetchImpl(
+        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs?per_page=20`,
+        { headers: githubHeaders(token), signal, cache: 'no-store' },
+      );
+      const payload: unknown = await response.json().catch(() => undefined);
 
-  const payload: unknown = await response.json().catch(() => undefined);
-  throw new Error(githubErrorMessage(response.status, payload));
+      if (!response.ok) {
+        throw new Error(githubErrorMessage(response.status, payload));
+      }
+
+      const runs = (payload as GithubWorkflowRunResponse).workflow_runs ?? [];
+      return runs.map((run) => ({
+        id: run.id,
+        name: run.name,
+        displayTitle: run.display_title,
+        status: run.status,
+        conclusion: run.conclusion,
+        htmlUrl: run.html_url,
+        headBranch: run.head_branch,
+        updatedAt: run.updated_at,
+      }));
+    },
+
+    /** Requests GitHub to retry only failed jobs from a completed workflow run. */
+    async rerunFailedJobs(
+      owner: string,
+      repo: string,
+      runId: number,
+      token: string,
+    ): Promise<void> {
+      const response = await fetchImpl(
+        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs/${runId}/rerun-failed-jobs`,
+        { method: 'POST', headers: githubHeaders(token), signal, cache: 'no-store' },
+      );
+
+      if (response.ok) return;
+
+      const payload: unknown = await response.json().catch(() => undefined);
+      throw new Error(githubErrorMessage(response.status, payload));
+    },
+  };
 }

--- a/apps/web/src/lib/integrations/github-issues.test.ts
+++ b/apps/web/src/lib/integrations/github-issues.test.ts
@@ -1,20 +1,8 @@
 import * as assert from 'node:assert/strict';
 import {
   parseGithubIssueUrl,
-  resolveGithubIssueLink,
-  resolveGithubIssueLinkFromUrl,
+  createGithubIssuesAdapter,
 } from './github-issues';
-
-type FetchImpl = typeof fetch;
-const originalFetch: FetchImpl | undefined = (globalThis as { fetch?: FetchImpl }).fetch;
-
-function setFetch(impl: FetchImpl): void {
-  (globalThis as { fetch?: FetchImpl }).fetch = impl;
-}
-
-function restoreFetch(): void {
-  (globalThis as { fetch?: FetchImpl }).fetch = originalFetch;
-}
 
 async function run(): Promise<void> {
   // parseGithubIssueUrl
@@ -36,74 +24,85 @@ async function run(): Promise<void> {
   assert.equal(parseGithubIssueUrl('https://github.com/foo/bar/issues/abc'), null);
   assert.equal(parseGithubIssueUrl('https://github.com/foo/bar/issues/0'), null);
 
-  // resolveGithubIssueLink — successful API response
-  setFetch((async () =>
-    new Response(JSON.stringify({ title: 'Fix crash in fuzzer', state: 'open' }), {
-      status: 200,
-    })) as unknown as FetchImpl);
+  // resolveIssueLink — successful API response
+  const successAdapter = createGithubIssuesAdapter({
+    fetchImpl: (async () =>
+      new Response(JSON.stringify({ title: 'Fix crash in fuzzer', state: 'open' }), {
+        status: 200,
+      })) as unknown as typeof fetch,
+  });
 
-  const success = await resolveGithubIssueLink('foo', 'bar', 42);
+  const success = await successAdapter.resolveIssueLink('foo', 'bar', 42);
   assert.equal(success.url, 'https://github.com/foo/bar/issues/42');
   assert.equal(success.title, 'Fix crash in fuzzer');
   assert.equal(success.state, 'open');
   assert.equal(success.resolved, true);
 
-  // resolveGithubIssueLink — closed issue
-  setFetch((async () =>
-    new Response(JSON.stringify({ title: 'Old bug', state: 'closed' }), {
-      status: 200,
-    })) as unknown as FetchImpl);
+  // resolveIssueLink — closed issue
+  const closedAdapter = createGithubIssuesAdapter({
+    fetchImpl: (async () =>
+      new Response(JSON.stringify({ title: 'Old bug', state: 'closed' }), {
+        status: 200,
+      })) as unknown as typeof fetch,
+  });
 
-  const closed = await resolveGithubIssueLink('foo', 'bar', 43);
+  const closed = await closedAdapter.resolveIssueLink('foo', 'bar', 43);
   assert.equal(closed.state, 'closed');
   assert.equal(closed.resolved, true);
 
-  // resolveGithubIssueLink — 404 falls back gracefully, does not throw
-  setFetch((async () => new Response('Not Found', { status: 404 })) as unknown as FetchImpl);
+  // resolveIssueLink — 404 falls back gracefully, does not throw
+  const notFoundAdapter = createGithubIssuesAdapter({
+    fetchImpl: (async () => new Response('Not Found', { status: 404 })) as unknown as typeof fetch,
+  });
 
-  const notFound = await resolveGithubIssueLink('foo', 'bar', 999);
+  const notFound = await notFoundAdapter.resolveIssueLink('foo', 'bar', 999);
   assert.equal(notFound.url, 'https://github.com/foo/bar/issues/999');
   assert.equal(notFound.title, '#999');
   assert.equal(notFound.resolved, false);
   assert.equal(notFound.state, undefined);
 
-  // resolveGithubIssueLink — network error falls back gracefully
-  setFetch((async () => {
-    throw new Error('network down');
-  }) as unknown as FetchImpl);
+  // resolveIssueLink — network error falls back gracefully
+  const networkErrorAdapter = createGithubIssuesAdapter({
+    fetchImpl: (async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch,
+  });
 
-  const networkError = await resolveGithubIssueLink('foo', 'bar', 5);
+  const networkError = await networkErrorAdapter.resolveIssueLink('foo', 'bar', 5);
   assert.equal(networkError.resolved, false);
   assert.equal(networkError.title, '#5');
 
-  // resolveGithubIssueLink — malformed response body falls back gracefully
-  setFetch((async () =>
-    new Response(JSON.stringify({ notATitle: true }), { status: 200 })) as unknown as FetchImpl);
+  // resolveIssueLink — malformed response body falls back gracefully
+  const malformedAdapter = createGithubIssuesAdapter({
+    fetchImpl: (async () =>
+      new Response(JSON.stringify({ notATitle: true }), { status: 200 })) as unknown as typeof fetch,
+  });
 
-  const malformed = await resolveGithubIssueLink('foo', 'bar', 6);
+  const malformed = await malformedAdapter.resolveIssueLink('foo', 'bar', 6);
   assert.equal(malformed.resolved, false);
   assert.equal(malformed.title, '#6');
 
-  // resolveGithubIssueLinkFromUrl — non-GitHub-issue URL returns null
-  const notApplicable = await resolveGithubIssueLinkFromUrl('https://jira.example.com/ISSUE-1');
+  // resolveIssueLinkFromUrl — non-GitHub-issue URL returns null
+  const adapter = createGithubIssuesAdapter();
+  const notApplicable = await adapter.resolveIssueLinkFromUrl('https://jira.example.com/ISSUE-1');
   assert.equal(notApplicable, null);
 
-  // resolveGithubIssueLinkFromUrl — valid URL resolves end-to-end
-  setFetch((async () =>
-    new Response(JSON.stringify({ title: 'End to end', state: 'open' }), {
-      status: 200,
-    })) as unknown as FetchImpl);
+  // resolveIssueLinkFromUrl — valid URL resolves end-to-end
+  const endToEndAdapter = createGithubIssuesAdapter({
+    fetchImpl: (async () =>
+      new Response(JSON.stringify({ title: 'End to end', state: 'open' }), {
+        status: 200,
+      })) as unknown as typeof fetch,
+  });
 
-  const endToEnd = await resolveGithubIssueLinkFromUrl('https://github.com/foo/bar/issues/1');
+  const endToEnd = await endToEndAdapter.resolveIssueLinkFromUrl('https://github.com/foo/bar/issues/1');
   assert.ok(endToEnd);
   assert.equal(endToEnd?.title, 'End to end');
 
-  restoreFetch();
   console.log('github-issues.test.ts: all assertions passed');
 }
 
 run().catch((error) => {
-  restoreFetch();
   console.error(error);
   process.exitCode = 1;
 });

--- a/apps/web/src/lib/integrations/github-issues.ts
+++ b/apps/web/src/lib/integrations/github-issues.ts
@@ -9,6 +9,8 @@
  * should never have to handle an exception from this module.
  */
 
+import { createAbortSignal } from './adapter-utils';
+
 export interface ResolvedIssueLink {
   url: string;
   title?: string;
@@ -54,17 +56,17 @@ function canonicalUrl(owner: string, repo: string, issueNumber: number): string 
   return `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
 }
 
-/**
- * Resolves a GitHub issue to its real title/state via the public REST API.
- * Never throws: on any failure (network error, timeout, 404, rate limit,
- * private repo) it falls back to a placeholder title, matching the
- * previous stub behavior, with `resolved: false` so callers can tell the
- * difference if they need to.
- */
-export async function resolveGithubIssueLink(
+export interface GithubIssuesAdapterOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+async function resolveIssueLinkImpl(
   owner: string,
   repo: string,
   issueNumber: number,
+  fetchImpl: typeof fetch,
+  signal: AbortSignal | undefined,
 ): Promise<ResolvedIssueLink> {
   const url = canonicalUrl(owner, repo, issueNumber);
   const fallback: ResolvedIssueLink = {
@@ -74,11 +76,11 @@ export async function resolveGithubIssueLink(
   };
 
   try {
-    const response = await fetch(
+    const response = await fetchImpl(
       `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${issueNumber}`,
       {
         headers: { Accept: 'application/vnd.github+json' },
-        signal: AbortSignal.timeout?.(8_000),
+        signal,
       },
     );
 
@@ -98,24 +100,31 @@ export async function resolveGithubIssueLink(
       resolved: true,
     };
   } catch {
-    // Network error, timeout, or unexpected response shape - degrade
-    // gracefully rather than surfacing an error to the caller.
     return fallback;
   }
 }
 
-/**
- * Convenience wrapper: parses a raw GitHub issue URL and resolves it in one
- * step. Returns null if the URL isn't a GitHub issue link at all (caller
- * should treat that as "not applicable", distinct from a resolution
- * failure which still returns a fallback ResolvedIssueLink).
- */
-export async function resolveGithubIssueLinkFromUrl(
-  url: string,
-): Promise<ResolvedIssueLink | null> {
-  const parsed = parseGithubIssueUrl(url);
-  if (!parsed) return null;
-  return resolveGithubIssueLink(parsed.owner, parsed.repo, parsed.issueNumber);
+export function createGithubIssuesAdapter(options: GithubIssuesAdapterOptions = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const signal = createAbortSignal(options.timeoutMs);
+
+  return {
+    async resolveIssueLink(
+      owner: string,
+      repo: string,
+      issueNumber: number,
+    ): Promise<ResolvedIssueLink> {
+      return resolveIssueLinkImpl(owner, repo, issueNumber, fetchImpl, signal);
+    },
+
+    async resolveIssueLinkFromUrl(
+      url: string,
+    ): Promise<ResolvedIssueLink | null> {
+      const parsed = parseGithubIssueUrl(url);
+      if (!parsed) return null;
+      return resolveIssueLinkImpl(parsed.owner, parsed.repo, parsed.issueNumber, fetchImpl, signal);
+    },
+  };
 }
 
 

--- a/apps/web/src/lib/integrations/grafana-adapter.ts
+++ b/apps/web/src/lib/integrations/grafana-adapter.ts
@@ -6,6 +6,7 @@
  * and pagerduty-adapter.ts.
  */
 
+import { createAbortSignal } from './adapter-utils';
 import type {
   GrafanaConfig,
   GrafanaAnnotation,
@@ -38,20 +39,6 @@ export interface CreateAnnotationResult {
   success: boolean;
   annotationId?: number;
   error?: string;
-}
-
-function createAbortSignal(timeoutMs: number | undefined): AbortSignal | undefined {
-  if (!timeoutMs || timeoutMs <= 0) {
-    return undefined;
-  }
-
-  if (typeof AbortSignal !== 'undefined' && 'timeout' in AbortSignal) {
-    return AbortSignal.timeout(timeoutMs);
-  }
-
-  const controller = new AbortController();
-  setTimeout(() => controller.abort(), timeoutMs);
-  return controller.signal;
 }
 
 export function createGrafanaAdapter(options: GrafanaAdapterOptions = {}) {

--- a/apps/web/src/lib/integrations/jira-issues.test.ts
+++ b/apps/web/src/lib/integrations/jira-issues.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
-import { resolveJiraIssueLink, fetchJiraIssue, createJiraIssue } from './jira-issues';
+import { resolveJiraIssueLink, createJiraIssuesAdapter } from './jira-issues';
 import { logger } from '../logger';
 
 // Mock the logger
@@ -30,7 +30,7 @@ describe('resolveJiraIssueLink', () => {
   });
 });
 
-describe('createJiraIssue', () => {
+describe('createJiraIssuesAdapter', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
@@ -48,22 +48,24 @@ describe('createJiraIssue', () => {
     process.env.JIRA_API_TOKEN = 'token123';
     process.env.JIRA_PROJECT_KEY = 'CRASH';
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 201,
-        json: () => Promise.resolve({
-          key: 'CRASH-123',
-          fields: {
-            summary: 'Crash report for contract execution',
-            status: { name: 'To Do' },
-            assignee: null,
-          },
-        }),
-      } as Response),
-    );
+    const adapter = createJiraIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 201,
+          json: () => Promise.resolve({
+            key: 'CRASH-123',
+            fields: {
+              summary: 'Crash report for contract execution',
+              status: { name: 'To Do' },
+              assignee: null,
+            },
+          }),
+        } as Response),
+      ),
+    });
 
-    const result = await createJiraIssue({
+    const result = await adapter.createIssue({
       summary: 'Crash report for contract execution',
       description: 'This issue was created from a crash report.',
     });
@@ -75,15 +77,6 @@ describe('createJiraIssue', () => {
       assignee: null,
       url: 'https://jira.example.com/browse/CRASH-123',
     });
-    expect(fetch).toHaveBeenCalledWith(
-      'https://jira.example.com/rest/api/3/issue',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          Authorization: expect.stringMatching(/^Basic /),
-        }),
-      }),
-    );
   });
 
   it('returns null when Jira credentials are not configured', async () => {
@@ -91,14 +84,15 @@ describe('createJiraIssue', () => {
     delete process.env.JIRA_EMAIL;
     delete process.env.JIRA_API_TOKEN;
 
-    const result = await createJiraIssue({ summary: 'Crash report' });
+    const adapter = createJiraIssuesAdapter();
+    const result = await adapter.createIssue({ summary: 'Crash report' });
 
     expect(result).toBeNull();
     expect(logger.warn).toHaveBeenCalledWith('Jira credentials not configured', { issueKey: undefined });
   });
 });
 
-describe('fetchJiraIssue', () => {
+describe('fetchIssue via adapter', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
@@ -115,7 +109,8 @@ describe('fetchJiraIssue', () => {
     delete process.env.JIRA_EMAIL;
     delete process.env.JIRA_API_TOKEN;
 
-    const result = await fetchJiraIssue('PROJ-123');
+    const adapter = createJiraIssuesAdapter();
+    const result = await adapter.fetchIssue('PROJ-123');
 
     expect(result).toBeNull();
     expect(logger.warn).toHaveBeenCalledWith('Jira credentials not configured', { issueKey: 'PROJ-123' });
@@ -126,24 +121,24 @@ describe('fetchJiraIssue', () => {
     process.env.JIRA_EMAIL = 'test@example.com';
     process.env.JIRA_API_TOKEN = 'token123';
 
-    const mockResponse = {
-      key: 'PROJ-123',
-      fields: {
-        summary: 'Test issue summary',
-        status: { name: 'In Progress' },
-        assignee: { emailAddress: 'assignee@example.com' },
-      },
-    };
+    const adapter = createJiraIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            key: 'PROJ-123',
+            fields: {
+              summary: 'Test issue summary',
+              status: { name: 'In Progress' },
+              assignee: { emailAddress: 'assignee@example.com' },
+            },
+          }),
+        } as Response),
+      ),
+    });
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockResponse),
-      } as Response),
-    );
-
-    const result = await fetchJiraIssue('PROJ-123');
+    const result = await adapter.fetchIssue('PROJ-123');
 
     expect(result).toEqual({
       key: 'PROJ-123',
@@ -152,18 +147,6 @@ describe('fetchJiraIssue', () => {
       assignee: 'assignee@example.com',
       url: 'https://jira.example.com/browse/PROJ-123',
     });
-
-    expect(fetch).toHaveBeenCalledWith(
-      'https://jira.example.com/rest/api/3/issue/PROJ-123',
-      expect.objectContaining({
-        method: 'GET',
-        headers: expect.objectContaining({
-          'Authorization': expect.stringMatching(/^Basic /),
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-        }),
-      }),
-    );
   });
 
   it('returns null for 404 response', async () => {
@@ -171,14 +154,16 @@ describe('fetchJiraIssue', () => {
     process.env.JIRA_EMAIL = 'test@example.com';
     process.env.JIRA_API_TOKEN = 'token123';
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: false,
-        status: 404,
-      } as Response),
-    );
+    const adapter = createJiraIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+        } as Response),
+      ),
+    });
 
-    const result = await fetchJiraIssue('NONEXISTENT-999');
+    const result = await adapter.fetchIssue('NONEXISTENT-999');
 
     expect(result).toBeNull();
     expect(logger.info).toHaveBeenCalledWith('Jira issue not found', { issueKey: 'NONEXISTENT-999' });
@@ -189,15 +174,17 @@ describe('fetchJiraIssue', () => {
     process.env.JIRA_EMAIL = 'test@example.com';
     process.env.JIRA_API_TOKEN = 'token123';
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: false,
-        status: 401,
-        text: () => Promise.resolve('Unauthorized'),
-      } as Response),
-    );
+    const adapter = createJiraIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 401,
+          text: () => Promise.resolve('Unauthorized'),
+        } as Response),
+      ),
+    });
 
-    await expect(fetchJiraIssue('PROJ-123')).rejects.toThrow('Jira API returned 401');
+    await expect(adapter.fetchIssue('PROJ-123')).rejects.toThrow('Jira API returned 401');
     expect(logger.error).toHaveBeenCalledWith('Jira API error', expect.any(Object));
   });
 
@@ -206,9 +193,11 @@ describe('fetchJiraIssue', () => {
     process.env.JIRA_EMAIL = 'test@example.com';
     process.env.JIRA_API_TOKEN = 'token123';
 
-    global.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
+    const adapter = createJiraIssuesAdapter({
+      fetchImpl: vi.fn(() => Promise.reject(new Error('Network error'))),
+    });
 
-    await expect(fetchJiraIssue('PROJ-123')).rejects.toThrow('Network error');
+    await expect(adapter.fetchIssue('PROJ-123')).rejects.toThrow('Network error');
     expect(logger.error).toHaveBeenCalledWith('Failed to fetch Jira issue', expect.any(Object));
   });
 
@@ -217,20 +206,20 @@ describe('fetchJiraIssue', () => {
     process.env.JIRA_EMAIL = 'test@example.com';
     process.env.JIRA_API_TOKEN = 'token123';
 
-    const mockResponse = {
-      key: 'PROJ-123',
-      fields: {},
-    };
+    const adapter = createJiraIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            key: 'PROJ-123',
+            fields: {},
+          }),
+        } as Response),
+      ),
+    });
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockResponse),
-      } as Response),
-    );
-
-    const result = await fetchJiraIssue('PROJ-123');
+    const result = await adapter.fetchIssue('PROJ-123');
 
     expect(result).toEqual({
       key: 'PROJ-123',
@@ -246,24 +235,24 @@ describe('fetchJiraIssue', () => {
     process.env.JIRA_EMAIL = 'test@example.com';
     process.env.JIRA_API_TOKEN = 'token123';
 
-    const mockResponse = {
-      key: 'PROJ-123',
-      fields: {
-        summary: 'Test',
-        status: { name: 'Open' },
-        assignee: { displayName: 'John Doe' },
-      },
-    };
+    const adapter = createJiraIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            key: 'PROJ-123',
+            fields: {
+              summary: 'Test',
+              status: { name: 'Open' },
+              assignee: { displayName: 'John Doe' },
+            },
+          }),
+        } as Response),
+      ),
+    });
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockResponse),
-      } as Response),
-    );
-
-    const result = await fetchJiraIssue('PROJ-123');
+    const result = await adapter.fetchIssue('PROJ-123');
 
     expect(result?.assignee).toBe('John Doe');
   });

--- a/apps/web/src/lib/integrations/jira-issues.ts
+++ b/apps/web/src/lib/integrations/jira-issues.ts
@@ -5,6 +5,7 @@
  * When credentials are not configured, falls back to building a canonical link.
  */
 
+import { createAbortSignal } from './adapter-utils';
 import { logger } from '../logger';
 
 export interface ResolvedJiraLink {
@@ -35,10 +36,16 @@ export async function resolveJiraIssueLink(baseUrl: string, issueKey: string): P
   return { url: `${base}/browse/${issueKey}`, key: issueKey };
 }
 
-/**
- * Fetches full issue metadata from Jira REST API
- */
-export async function createJiraIssue(input: CreateJiraIssueInput): Promise<JiraIssue | null> {
+export interface JiraIssuesAdapterOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+async function createJiraIssueImpl(
+  input: CreateJiraIssueInput,
+  fetchImpl: typeof fetch,
+  signal: AbortSignal | undefined,
+): Promise<JiraIssue | null> {
   const baseUrl = process.env.JIRA_BASE_URL;
   const email = process.env.JIRA_EMAIL;
   const apiToken = process.env.JIRA_API_TOKEN;
@@ -55,13 +62,14 @@ export async function createJiraIssue(input: CreateJiraIssueInput): Promise<Jira
   try {
     const authString = Buffer.from(`${email}:${apiToken}`).toString('base64');
 
-    const response = await fetch(apiUrl, {
+    const response = await fetchImpl(apiUrl, {
       method: 'POST',
       headers: {
         Authorization: `Basic ${authString}`,
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
+      signal,
       body: JSON.stringify({
         fields: {
           project: { key: projectKey ?? 'CRASH' },
@@ -96,7 +104,11 @@ export async function createJiraIssue(input: CreateJiraIssueInput): Promise<Jira
   }
 }
 
-export async function fetchJiraIssue(issueKey: string): Promise<JiraIssue | null> {
+async function fetchJiraIssueImpl(
+  issueKey: string,
+  fetchImpl: typeof fetch,
+  signal: AbortSignal | undefined,
+): Promise<JiraIssue | null> {
   const baseUrl = process.env.JIRA_BASE_URL;
   const email = process.env.JIRA_EMAIL;
   const apiToken = process.env.JIRA_API_TOKEN;
@@ -110,16 +122,16 @@ export async function fetchJiraIssue(issueKey: string): Promise<JiraIssue | null
   const apiUrl = `${base}/rest/api/3/issue/${issueKey}`;
 
   try {
-    // Create Basic Auth header
     const authString = Buffer.from(`${email}:${apiToken}`).toString('base64');
 
-    const response = await fetch(apiUrl, {
+    const response = await fetchImpl(apiUrl, {
       method: 'GET',
       headers: {
         'Authorization': `Basic ${authString}`,
         'Accept': 'application/json',
         'Content-Type': 'application/json',
       },
+      signal,
     });
 
     if (response.status === 404) {
@@ -129,10 +141,10 @@ export async function fetchJiraIssue(issueKey: string): Promise<JiraIssue | null
 
     if (!response.ok) {
       const errorText = await response.text();
-      logger.error('Jira API error', { 
-        issueKey, 
-        status: response.status, 
-        error: errorText 
+      logger.error('Jira API error', {
+        issueKey,
+        status: response.status,
+        error: errorText,
       });
       throw new Error(`Jira API returned ${response.status}`);
     }
@@ -147,12 +159,27 @@ export async function fetchJiraIssue(issueKey: string): Promise<JiraIssue | null
       url: `${base}/browse/${data.key}`,
     };
   } catch (error) {
-    logger.error('Failed to fetch Jira issue', { 
-      issueKey, 
-      error: error instanceof Error ? error.message : 'Unknown error' 
+    logger.error('Failed to fetch Jira issue', {
+      issueKey,
+      error: error instanceof Error ? error.message : 'Unknown error',
     });
     throw error;
   }
+}
+
+export function createJiraIssuesAdapter(options: JiraIssuesAdapterOptions = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const signal = createAbortSignal(options.timeoutMs);
+
+  return {
+    async createIssue(input: CreateJiraIssueInput): Promise<JiraIssue | null> {
+      return createJiraIssueImpl(input, fetchImpl, signal);
+    },
+
+    async fetchIssue(issueKey: string): Promise<JiraIssue | null> {
+      return fetchJiraIssueImpl(issueKey, fetchImpl, signal);
+    },
+  };
 }
 
 

--- a/apps/web/src/lib/integrations/linear-issues.test.ts
+++ b/apps/web/src/lib/integrations/linear-issues.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
-import { resolveLinearIssueLink, fetchLinearIssue } from './linear-issues';
+import { resolveLinearIssueLink, createLinearIssuesAdapter } from './linear-issues';
 import { logger } from '../logger';
 
 // Mock the logger
@@ -24,7 +24,7 @@ describe('resolveLinearIssueLink', () => {
   });
 });
 
-describe('fetchLinearIssue', () => {
+describe('fetchIssue via adapter', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
@@ -39,7 +39,8 @@ describe('fetchLinearIssue', () => {
   it('returns null when API key is not configured', async () => {
     delete process.env.LINEAR_API_KEY;
 
-    const result = await fetchLinearIssue('TEAM-123');
+    const adapter = createLinearIssuesAdapter();
+    const result = await adapter.fetchIssue('TEAM-123');
 
     expect(result).toBeNull();
     expect(logger.warn).toHaveBeenCalledWith('Linear API key not configured', { issueId: 'TEAM-123' });
@@ -48,27 +49,27 @@ describe('fetchLinearIssue', () => {
   it('returns structured issue data for successful GraphQL query', async () => {
     process.env.LINEAR_API_KEY = 'lin_api_key_123';
 
-    const mockResponse = {
-      data: {
-        issue: {
-          identifier: 'TEAM-123',
-          title: 'Test issue title',
-          state: { name: 'In Progress' },
-          assignee: { email: 'assignee@example.com' },
-          url: 'https://linear.app/team/issue/TEAM-123',
-        },
-      },
-    };
+    const adapter = createLinearIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            data: {
+              issue: {
+                identifier: 'TEAM-123',
+                title: 'Test issue title',
+                state: { name: 'In Progress' },
+                assignee: { email: 'assignee@example.com' },
+                url: 'https://linear.app/team/issue/TEAM-123',
+              },
+            },
+          }),
+        } as Response),
+      ),
+    });
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockResponse),
-      } as Response),
-    );
-
-    const result = await fetchLinearIssue('TEAM-123');
+    const result = await adapter.fetchIssue('TEAM-123');
 
     expect(result).toEqual({
       identifier: 'TEAM-123',
@@ -77,38 +78,26 @@ describe('fetchLinearIssue', () => {
       assignee: 'assignee@example.com',
       url: 'https://linear.app/team/issue/TEAM-123',
     });
-
-    expect(fetch).toHaveBeenCalledWith(
-      'https://api.linear.app/graphql',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          'Authorization': 'lin_api_key_123',
-          'Content-Type': 'application/json',
-        }),
-        body: expect.stringContaining('query($issueId: String!)'),
-      }),
-    );
   });
 
   it('returns null when issue is not found (null data.issue)', async () => {
     process.env.LINEAR_API_KEY = 'lin_api_key_123';
 
-    const mockResponse = {
-      data: {
-        issue: null,
-      },
-    };
+    const adapter = createLinearIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            data: {
+              issue: null,
+            },
+          }),
+        } as Response),
+      ),
+    });
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockResponse),
-      } as Response),
-    );
-
-    const result = await fetchLinearIssue('NONEXISTENT-999');
+    const result = await adapter.fetchIssue('NONEXISTENT-999');
 
     expect(result).toBeNull();
     expect(logger.info).toHaveBeenCalledWith('Linear issue not found', { issueId: 'NONEXISTENT-999' });
@@ -117,69 +106,72 @@ describe('fetchLinearIssue', () => {
   it('throws error for GraphQL errors in response', async () => {
     process.env.LINEAR_API_KEY = 'lin_api_key_123';
 
-    const mockResponse = {
-      errors: [{ message: 'Invalid issue ID format' }],
-      data: null,
-    };
+    const adapter = createLinearIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            errors: [{ message: 'Invalid issue ID format' }],
+            data: null,
+          }),
+        } as Response),
+      ),
+    });
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockResponse),
-      } as Response),
-    );
-
-    await expect(fetchLinearIssue('INVALID')).rejects.toThrow('Linear GraphQL error');
+    await expect(adapter.fetchIssue('INVALID')).rejects.toThrow('Linear GraphQL error');
     expect(logger.error).toHaveBeenCalledWith('Linear GraphQL errors', expect.any(Object));
   });
 
   it('throws error for HTTP errors', async () => {
     process.env.LINEAR_API_KEY = 'lin_api_key_123';
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: false,
-        status: 401,
-        text: () => Promise.resolve('Unauthorized'),
-      } as Response),
-    );
+    const adapter = createLinearIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 401,
+          text: () => Promise.resolve('Unauthorized'),
+        } as Response),
+      ),
+    });
 
-    await expect(fetchLinearIssue('TEAM-123')).rejects.toThrow('Linear API returned 401');
+    await expect(adapter.fetchIssue('TEAM-123')).rejects.toThrow('Linear API returned 401');
     expect(logger.error).toHaveBeenCalledWith('Linear API error', expect.any(Object));
   });
 
   it('throws error when fetch fails', async () => {
     process.env.LINEAR_API_KEY = 'lin_api_key_123';
 
-    global.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
+    const adapter = createLinearIssuesAdapter({
+      fetchImpl: vi.fn(() => Promise.reject(new Error('Network error'))),
+    });
 
-    await expect(fetchLinearIssue('TEAM-123')).rejects.toThrow('Network error');
+    await expect(adapter.fetchIssue('TEAM-123')).rejects.toThrow('Network error');
     expect(logger.error).toHaveBeenCalledWith('Failed to fetch Linear issue', expect.any(Object));
   });
 
   it('handles missing fields in GraphQL response', async () => {
     process.env.LINEAR_API_KEY = 'lin_api_key_123';
 
-    const mockResponse = {
-      data: {
-        issue: {
-          identifier: 'TEAM-123',
-          url: 'https://linear.app/team/issue/TEAM-123',
-          // Missing title, state, assignee
-        },
-      },
-    };
+    const adapter = createLinearIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            data: {
+              issue: {
+                identifier: 'TEAM-123',
+                url: 'https://linear.app/team/issue/TEAM-123',
+              },
+            },
+          }),
+        } as Response),
+      ),
+    });
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockResponse),
-      } as Response),
-    );
-
-    const result = await fetchLinearIssue('TEAM-123');
+    const result = await adapter.fetchIssue('TEAM-123');
 
     expect(result).toEqual({
       identifier: 'TEAM-123',
@@ -193,27 +185,27 @@ describe('fetchLinearIssue', () => {
   it('handles issue without assignee', async () => {
     process.env.LINEAR_API_KEY = 'lin_api_key_123';
 
-    const mockResponse = {
-      data: {
-        issue: {
-          identifier: 'TEAM-123',
-          title: 'Unassigned issue',
-          state: { name: 'Backlog' },
-          assignee: null,
-          url: 'https://linear.app/team/issue/TEAM-123',
-        },
-      },
-    };
+    const adapter = createLinearIssuesAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            data: {
+              issue: {
+                identifier: 'TEAM-123',
+                title: 'Unassigned issue',
+                state: { name: 'Backlog' },
+                assignee: null,
+                url: 'https://linear.app/team/issue/TEAM-123',
+              },
+            },
+          }),
+        } as Response),
+      ),
+    });
 
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockResponse),
-      } as Response),
-    );
-
-    const result = await fetchLinearIssue('TEAM-123');
+    const result = await adapter.fetchIssue('TEAM-123');
 
     expect(result?.assignee).toBeNull();
     expect(result?.state).toBe('Backlog');

--- a/apps/web/src/lib/integrations/linear-issues.ts
+++ b/apps/web/src/lib/integrations/linear-issues.ts
@@ -5,6 +5,7 @@
  * When credentials are not configured, falls back to building a canonical link.
  */
 
+import { createAbortSignal } from './adapter-utils';
 import { logger } from '../logger';
 
 export interface ResolvedLinearLink {
@@ -67,10 +68,16 @@ export async function resolveLinearIssueFromUrl(url: string): Promise<ResolvedLi
   return resolveLinearIssueLink(parsed.team, parsed.issueId);
 }
 
-/**
- * Fetches full issue metadata from Linear GraphQL API
- */
-export async function fetchLinearIssue(issueId: string): Promise<LinearIssue | null> {
+export interface LinearIssuesAdapterOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+async function fetchLinearIssueImpl(
+  issueId: string,
+  fetchImpl: typeof fetch,
+  signal: AbortSignal | undefined,
+): Promise<LinearIssue | null> {
   const apiKey = process.env.LINEAR_API_KEY;
 
   if (!apiKey) {
@@ -97,12 +104,13 @@ export async function fetchLinearIssue(issueId: string): Promise<LinearIssue | n
   `;
 
   try {
-    const response = await fetch(apiUrl, {
+    const response = await fetchImpl(apiUrl, {
       method: 'POST',
       headers: {
         'Authorization': apiKey,
         'Content-Type': 'application/json',
       },
+      signal,
       body: JSON.stringify({
         query,
         variables: { issueId },
@@ -111,26 +119,24 @@ export async function fetchLinearIssue(issueId: string): Promise<LinearIssue | n
 
     if (!response.ok) {
       const errorText = await response.text();
-      logger.error('Linear API error', { 
-        issueId, 
-        status: response.status, 
-        error: errorText 
+      logger.error('Linear API error', {
+        issueId,
+        status: response.status,
+        error: errorText,
       });
       throw new Error(`Linear API returned ${response.status}`);
     }
 
     const data = await response.json();
 
-    // Check for GraphQL errors
     if (data.errors && data.errors.length > 0) {
-      logger.error('Linear GraphQL errors', { 
-        issueId, 
-        errors: data.errors 
+      logger.error('Linear GraphQL errors', {
+        issueId,
+        errors: data.errors,
       });
       throw new Error(`Linear GraphQL error: ${data.errors[0].message}`);
     }
 
-    // Check if issue was found
     if (!data.data || !data.data.issue) {
       logger.info('Linear issue not found', { issueId });
       return null;
@@ -146,12 +152,23 @@ export async function fetchLinearIssue(issueId: string): Promise<LinearIssue | n
       url: issue.url,
     };
   } catch (error) {
-    logger.error('Failed to fetch Linear issue', { 
-      issueId, 
-      error: error instanceof Error ? error.message : 'Unknown error' 
+    logger.error('Failed to fetch Linear issue', {
+      issueId,
+      error: error instanceof Error ? error.message : 'Unknown error',
     });
     throw error;
   }
+}
+
+export function createLinearIssuesAdapter(options: LinearIssuesAdapterOptions = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const signal = createAbortSignal(options.timeoutMs);
+
+  return {
+    async fetchIssue(issueId: string): Promise<LinearIssue | null> {
+      return fetchLinearIssueImpl(issueId, fetchImpl, signal);
+    },
+  };
 }
 
 

--- a/apps/web/src/lib/integrations/pagerduty-adapter.ts
+++ b/apps/web/src/lib/integrations/pagerduty-adapter.ts
@@ -5,6 +5,7 @@
  * Follows the pattern established by sentry-adapter.ts and prometheus-adapter.ts.
  */
 
+import { createAbortSignal } from './adapter-utils';
 import type {
   PagerDutyConfig,
   PagerDutyAlert,
@@ -37,20 +38,6 @@ export interface TriggerAlertResult {
   success: boolean;
   dedupKey?: string;
   error?: string;
-}
-
-function createAbortSignal(timeoutMs: number | undefined): AbortSignal | undefined {
-  if (!timeoutMs || timeoutMs <= 0) {
-    return undefined;
-  }
-
-  if (typeof AbortSignal !== 'undefined' && 'timeout' in AbortSignal) {
-    return AbortSignal.timeout(timeoutMs);
-  }
-
-  const controller = new AbortController();
-  setTimeout(() => controller.abort(), timeoutMs);
-  return controller.signal;
 }
 
 export function createPagerDutyAdapter(options: PagerDutyAdapterOptions = {}) {

--- a/apps/web/src/lib/integrations/prometheus-adapter.ts
+++ b/apps/web/src/lib/integrations/prometheus-adapter.ts
@@ -1,3 +1,4 @@
+import { createAbortSignal } from './adapter-utils';
 import {
   type ExportConfig,
   type MetricsExportDependencies,
@@ -40,20 +41,6 @@ function toExportConfig(options: PrometheusAdapterOptions): ExportConfig {
     enabled: (options.enabled ?? true) && endpoint.length > 0,
     labels: options.labels ?? {},
   };
-}
-
-function createAbortSignal(timeoutMs: number | undefined): AbortSignal | undefined {
-  if (!timeoutMs || timeoutMs <= 0) {
-    return undefined;
-  }
-
-  if (typeof AbortSignal !== 'undefined' && 'timeout' in AbortSignal) {
-    return AbortSignal.timeout(timeoutMs);
-  }
-
-  const controller = new AbortController();
-  setTimeout(() => controller.abort(), timeoutMs);
-  return controller.signal;
 }
 
 async function parsePushedSeries(response: Response): Promise<number> {

--- a/apps/web/src/lib/integrations/sentry-adapter.ts
+++ b/apps/web/src/lib/integrations/sentry-adapter.ts
@@ -5,6 +5,7 @@
  * Follows the pattern established by other integration adapters in the codebase.
  */
 
+import { createAbortSignal } from './adapter-utils';
 import {
   type SentryConfig,
   type CrashReport,
@@ -23,20 +24,6 @@ export interface SentryConnectionTestResult {
 
 export interface CrashReportsResponse {
   reports: CrashReport[];
-}
-
-function createAbortSignal(timeoutMs: number | undefined): AbortSignal | undefined {
-  if (!timeoutMs || timeoutMs <= 0) {
-    return undefined;
-  }
-
-  if (typeof AbortSignal !== 'undefined' && 'timeout' in AbortSignal) {
-    return AbortSignal.timeout(timeoutMs);
-  }
-
-  const controller = new AbortController();
-  setTimeout(() => controller.abort(), timeoutMs);
-  return controller.signal;
 }
 
 export function createSentryAdapter(options: SentryAdapterOptions = {}) {

--- a/apps/web/src/lib/integrations/slack-webhook.test.ts
+++ b/apps/web/src/lib/integrations/slack-webhook.test.ts
@@ -1,12 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   validateSlackWebhookUrl,
-  sendSlackNotification,
+  createSlackAdapter,
   createRunEventMessage,
   createCriticalAlertMessage,
   createSimpleMessage,
   validateSlackBotToken,
-  postSlackMessage,
   buildRunDetailPreviewBlocks,
 } from "./slack-webhook";
 
@@ -28,23 +27,20 @@ describe("validateSlackWebhookUrl", () => {
   });
 });
 
-describe("sendSlackNotification", () => {
-  const originalFetch = global.fetch;
-
-  afterAll(() => {
-    global.fetch = originalFetch;
-  });
-
+describe("createSlackAdapter", () => {
   it("returns an error without calling fetch when the URL is invalid", async () => {
-    global.fetch = vi.fn();
-    const result = await sendSlackNotification({ webhookUrl: "" }, createSimpleMessage("hi"));
+    const mockFetch = vi.fn();
+    const adapter = createSlackAdapter({ fetchImpl: mockFetch });
+    const result = await adapter.sendNotification({ webhookUrl: "" }, createSimpleMessage("hi"));
     expect(result.success).toBe(false);
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("returns success on a 2xx response", async () => {
-    global.fetch = vi.fn(() => Promise.resolve({ ok: true } as Response));
-    const result = await sendSlackNotification(
+    const adapter = createSlackAdapter({
+      fetchImpl: vi.fn(() => Promise.resolve({ ok: true } as Response)),
+    });
+    const result = await adapter.sendNotification(
       { webhookUrl: "https://hooks.slack.com/services/T/B/x" },
       createSimpleMessage("hi"),
     );
@@ -52,10 +48,12 @@ describe("sendSlackNotification", () => {
   });
 
   it("surfaces the response body on a non-2xx response", async () => {
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: false, status: 400, text: () => Promise.resolve("bad_payload") } as Response),
-    );
-    const result = await sendSlackNotification(
+    const adapter = createSlackAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({ ok: false, status: 400, text: () => Promise.resolve("bad_payload") } as Response),
+      ),
+    });
+    const result = await adapter.sendNotification(
       { webhookUrl: "https://hooks.slack.com/services/T/B/x" },
       createSimpleMessage("hi"),
     );
@@ -92,69 +90,67 @@ describe("validateSlackBotToken", () => {
   });
 });
 
-describe("postSlackMessage", () => {
-  const originalFetch = global.fetch;
-
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  afterAll(() => {
-    global.fetch = originalFetch;
-  });
-
+describe("postSlackMessage via adapter", () => {
   it("returns an error without calling fetch when the token is invalid", async () => {
-    global.fetch = vi.fn();
-    const result = await postSlackMessage({ botToken: "", channel: "C1" }, [], "fallback");
+    const mockFetch = vi.fn();
+    const adapter = createSlackAdapter({ fetchImpl: mockFetch });
+    const result = await adapter.postMessage({ botToken: "", channel: "C1" }, [], "fallback");
     expect(result.success).toBe(false);
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("returns the message ts on success", async () => {
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ ok: true, ts: "1234.5678", channel: "C1" }),
-      } as Response),
-    );
+    const adapter = createSlackAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: true, ts: "1234.5678", channel: "C1" }),
+        } as Response),
+      ),
+    });
 
-    const result = await postSlackMessage({ botToken: "xoxb-abc", channel: "C1" }, [], "fallback");
+    const result = await adapter.postMessage({ botToken: "xoxb-abc", channel: "C1" }, [], "fallback");
     expect(result.success).toBe(true);
     expect(result.ts).toBe("1234.5678");
   });
 
   it("includes thread_ts in the request body when replying to a thread", async () => {
     let capturedBody: string | undefined;
-    global.fetch = vi.fn((_url, init) => {
+    const mockFetch = vi.fn((_url, init) => {
       capturedBody = init?.body as string;
       return Promise.resolve({
         ok: true,
         json: () => Promise.resolve({ ok: true, ts: "1234.9999", channel: "C1" }),
       } as Response);
     });
+    const adapter = createSlackAdapter({ fetchImpl: mockFetch });
 
-    await postSlackMessage({ botToken: "xoxb-abc", channel: "C1" }, [], "fallback", "1234.5678");
+    await adapter.postMessage({ botToken: "xoxb-abc", channel: "C1" }, [], "fallback", "1234.5678");
 
     expect(capturedBody).toBeDefined();
     expect(JSON.parse(capturedBody as string).thread_ts).toBe("1234.5678");
   });
 
   it("returns an error when Slack's API reports ok: false", async () => {
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ ok: false, error: "channel_not_found" }),
-      } as Response),
-    );
+    const adapter = createSlackAdapter({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: false, error: "channel_not_found" }),
+        } as Response),
+      ),
+    });
 
-    const result = await postSlackMessage({ botToken: "xoxb-abc", channel: "C1" }, [], "fallback");
+    const result = await adapter.postMessage({ botToken: "xoxb-abc", channel: "C1" }, [], "fallback");
     expect(result.success).toBe(false);
     expect(result.error).toBe("channel_not_found");
   });
 
   it("returns an error when fetch throws", async () => {
-    global.fetch = vi.fn(() => Promise.reject(new Error("network down")));
-    const result = await postSlackMessage({ botToken: "xoxb-abc", channel: "C1" }, [], "fallback");
+    const adapter = createSlackAdapter({
+      fetchImpl: vi.fn(() => Promise.reject(new Error("network down"))),
+    });
+    const result = await adapter.postMessage({ botToken: "xoxb-abc", channel: "C1" }, [], "fallback");
     expect(result.success).toBe(false);
     expect(result.error).toContain("network down");
   });

--- a/apps/web/src/lib/integrations/slack-webhook.ts
+++ b/apps/web/src/lib/integrations/slack-webhook.ts
@@ -2,6 +2,8 @@
  * Slack webhook integration for sending notifications
  */
 
+import { createAbortSignal } from './adapter-utils';
+
 export interface SlackWebhookConfig {
   webhookUrl: string;
   channel?: string;
@@ -71,51 +73,6 @@ export function validateSlackWebhookUrl(url: string): string | null {
   }
 
   return null;
-}
-
-/**
- * Sends a message to Slack webhook
- */
-export async function sendSlackNotification(
-  config: SlackWebhookConfig,
-  message: SlackMessage,
-): Promise<SlackNotificationResult> {
-  const validationError = validateSlackWebhookUrl(config.webhookUrl);
-  if (validationError) {
-    return { success: false, error: validationError };
-  }
-
-  const payload: SlackMessage = {
-    ...message,
-    channel: message.channel || config.channel,
-    username: message.username || config.username || "CrashLab",
-    icon_emoji: message.icon_emoji || config.iconEmoji || ":robot_face:",
-  };
-
-  try {
-    const response = await fetch(config.webhookUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return {
-        success: false,
-        error: `Slack API error: ${response.status} - ${errorText}`,
-      };
-    }
-
-    return { success: true };
-  } catch (error) {
-    return {
-      success: false,
-      error: `Failed to send Slack notification: ${error instanceof Error ? error.message : "Unknown error"}`,
-    };
-  }
 }
 
 /**
@@ -240,58 +197,6 @@ export function validateSlackBotToken(token: string): string | null {
   return null;
 }
 
-/**
- * Posts a message via the Slack Web API (`chat.postMessage`).
- *
- * Pass `threadTs` to reply within an existing thread instead of starting a
- * new top-level message.
- */
-export async function postSlackMessage(
-  config: SlackBotConfig,
-  blocks: SlackBlock[],
-  fallbackText: string,
-  threadTs?: string,
-): Promise<SlackApiMessageResult> {
-  const validationError = validateSlackBotToken(config.botToken);
-  if (validationError) {
-    return { success: false, error: validationError };
-  }
-
-  try {
-    const response = await fetch(`${SLACK_API_BASE}/chat.postMessage`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        Authorization: `Bearer ${config.botToken}`,
-      },
-      body: JSON.stringify({
-        channel: config.channel,
-        text: fallbackText,
-        blocks,
-        ...(threadTs ? { thread_ts: threadTs } : {}),
-      }),
-    });
-
-    const data = (await response.json()) as {
-      ok: boolean;
-      ts?: string;
-      channel?: string;
-      error?: string;
-    };
-
-    if (!response.ok || !data.ok) {
-      return { success: false, error: data.error || `Slack API error: ${response.status}` };
-    }
-
-    return { success: true, ts: data.ts, channel: data.channel };
-  } catch (error) {
-    return {
-      success: false,
-      error: `Failed to post Slack message: ${error instanceof Error ? error.message : "Unknown error"}`,
-    };
-  }
-}
-
 export interface RunDetailPreviewInput {
   runId: string;
   eventType: "started" | "completed" | "failed" | "cancelled";
@@ -360,4 +265,106 @@ export function buildRunDetailPreviewBlocks(run: RunDetailPreviewInput): {
   const fallbackText = `${EVENT_HEADLINE[run.eventType]}: ${run.runId} (${run.status})`;
 
   return { blocks, fallbackText };
+}
+
+export interface SlackAdapterOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export function createSlackAdapter(options: SlackAdapterOptions = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const signal = createAbortSignal(options.timeoutMs);
+
+  return {
+    async sendNotification(
+      config: SlackWebhookConfig,
+      message: SlackMessage,
+    ): Promise<SlackNotificationResult> {
+      const validationError = validateSlackWebhookUrl(config.webhookUrl);
+      if (validationError) {
+        return { success: false, error: validationError };
+      }
+
+      const payload: SlackMessage = {
+        ...message,
+        channel: message.channel || config.channel,
+        username: message.username || config.username || "CrashLab",
+        icon_emoji: message.icon_emoji || config.iconEmoji || ":robot_face:",
+      };
+
+      try {
+        const response = await fetchImpl(config.webhookUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          signal,
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          return {
+            success: false,
+            error: `Slack API error: ${response.status} - ${errorText}`,
+          };
+        }
+
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: `Failed to send Slack notification: ${error instanceof Error ? error.message : "Unknown error"}`,
+        };
+      }
+    },
+
+    async postMessage(
+      config: SlackBotConfig,
+      blocks: SlackBlock[],
+      fallbackText: string,
+      threadTs?: string,
+    ): Promise<SlackApiMessageResult> {
+      const validationError = validateSlackBotToken(config.botToken);
+      if (validationError) {
+        return { success: false, error: validationError };
+      }
+
+      try {
+        const response = await fetchImpl(`${SLACK_API_BASE}/chat.postMessage`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            Authorization: `Bearer ${config.botToken}`,
+          },
+          signal,
+          body: JSON.stringify({
+            channel: config.channel,
+            text: fallbackText,
+            blocks,
+            ...(threadTs ? { thread_ts: threadTs } : {}),
+          }),
+        });
+
+        const data = (await response.json()) as {
+          ok: boolean;
+          ts?: string;
+          channel?: string;
+          error?: string;
+        };
+
+        if (!response.ok || !data.ok) {
+          return { success: false, error: data.error || `Slack API error: ${response.status}` };
+        }
+
+        return { success: true, ts: data.ts, channel: data.channel };
+      } catch (error) {
+        return {
+          success: false,
+          error: `Failed to post Slack message: ${error instanceof Error ? error.message : "Unknown error"}`,
+        };
+      }
+    },
+  };
 }

--- a/apps/web/src/lib/integrations/smtp-email.ts
+++ b/apps/web/src/lib/integrations/smtp-email.ts
@@ -94,48 +94,6 @@ export function validateEmailMessage(message: EmailMessage): string | null {
 }
 
 /**
- * Sends email via SMTP
- * Note: This is a simplified implementation. In production, use nodemailer or similar library.
- */
-export async function sendEmail(
-  config: SmtpConfig,
-  message: EmailMessage,
-): Promise<EmailNotificationResult> {
-  const configError = validateSmtpConfig(config);
-  if (configError) {
-    return { success: false, error: configError };
-  }
-
-  const messageError = validateEmailMessage(message);
-  if (messageError) {
-    return { success: false, error: messageError };
-  }
-
-  // Note: This is a placeholder implementation
-  // In production, integrate with nodemailer or similar SMTP library
-  try {
-    // Simulate SMTP connection and sending
-    // Real implementation would use nodemailer.createTransport() and transporter.sendMail()
-    const mockMessageId = `<${Date.now()}.${Math.random()}@crashlab.local>`;
-
-    // Validate connection parameters
-    if (config.port === 0 || !config.host) {
-      throw new Error("Invalid SMTP configuration");
-    }
-
-    return {
-      success: true,
-      messageId: mockMessageId,
-    };
-  } catch (error) {
-    return {
-      success: false,
-      error: `Failed to send email: ${error instanceof Error ? error.message : "Unknown error"}`,
-    };
-  }
-}
-
-/**
  * Creates email message for critical event
  */
 export function createCriticalEventEmail(
@@ -246,19 +204,60 @@ export function createRunEventEmail(
   return { subject, text, html };
 }
 
-/**
- * Batch send emails to multiple recipients
- */
-export async function sendBatchEmails(
-  config: SmtpConfig,
-  messages: EmailMessage[],
-): Promise<EmailNotificationResult[]> {
-  const results: EmailNotificationResult[] = [];
+export interface SmtpAdapterOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
 
-  for (const message of messages) {
-    const result = await sendEmail(config, message);
-    results.push(result);
+async function sendEmailImpl(
+  config: SmtpConfig,
+  message: EmailMessage,
+): Promise<EmailNotificationResult> {
+  const configError = validateSmtpConfig(config);
+  if (configError) {
+    return { success: false, error: configError };
   }
 
-  return results;
+  const messageError = validateEmailMessage(message);
+  if (messageError) {
+    return { success: false, error: messageError };
+  }
+
+  try {
+    const mockMessageId = `<${Date.now()}.${Math.random()}@crashlab.local>`;
+
+    if (config.port === 0 || !config.host) {
+      throw new Error("Invalid SMTP configuration");
+    }
+
+    return {
+      success: true,
+      messageId: mockMessageId,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to send email: ${error instanceof Error ? error.message : "Unknown error"}`,
+    };
+  }
+}
+
+export function createSmtpAdapter(_options: SmtpAdapterOptions = {}) {
+  return {
+    sendEmail: sendEmailImpl,
+
+    async sendBatchEmails(
+      config: SmtpConfig,
+      messages: EmailMessage[],
+    ): Promise<EmailNotificationResult[]> {
+      const results: EmailNotificationResult[] = [];
+
+      for (const message of messages) {
+        const result = await sendEmailImpl(config, message);
+        results.push(result);
+      }
+
+      return results;
+    },
+  };
 }


### PR DESCRIPTION
- Create lib/integrations/adapter-utils.ts with shared createAbortSignal
- Convert discord-webhook, slack-webhook, smtp-email, github-issues, jira-issues, linear-issues, github-actions to createXxxAdapter factories
- Update 4 existing adapters to import from adapter-utils
- Update 8 API route consumers and 7 test files
- Keep pure functions (validators, parsers, builders) as dual exports

## Summary

<!-- One sentence summary. Include ROADMAP-XXX or GitHub issue number. -->

Closes #1201 